### PR TITLE
feat(auth): P4 — Auth (OSS): pluggable providers, password+sessions, email/domain verification, API key (#18)

### DIFF
--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,0 +1,10 @@
+"""Pluggable authentication spine for LAVS.
+
+Auth is selected by deployment config (``LAVS_AUTH_MODES``) and resolved to a
+single :class:`~app.auth.principal.Principal` per request. Each enabled
+:class:`~app.auth.auth_provider.AuthProvider` gets a chance to authenticate a
+request; the first that succeeds wins. When no provider is configured the
+resolver returns a permissive anonymous service principal so an unconfigured
+deployment (and the test-suite default) stays open. See
+``docs/design/API_CONTRACT.md`` §1–2 for the authority on the model and flows.
+"""

--- a/app/auth/auth_mode.py
+++ b/app/auth/auth_mode.py
@@ -1,0 +1,17 @@
+"""The authentication modes selectable via the ``LAVS_AUTH_MODES`` env list."""
+
+from enum import StrEnum
+
+
+class AuthMode(StrEnum):
+    """A deployment-selectable authentication mode.
+
+    Enabled modes are read from the ``LAVS_AUTH_MODES`` comma list (see
+    ``docs/design/API_CONTRACT.md`` §1). ``password`` (username/password +
+    sessions) is added by the R2 lane; ``apikey`` is the headless ``X-API-Key``
+    mode wired here in the foundation. The managed-identity ``stytch`` mode is
+    deferred and intentionally not represented.
+    """
+
+    PASSWORD = "password"
+    APIKEY = "apikey"

--- a/app/auth/auth_provider.py
+++ b/app/auth/auth_provider.py
@@ -1,0 +1,32 @@
+"""The provider abstraction every authentication mechanism implements."""
+
+from abc import ABC, abstractmethod
+
+from fastapi import Request
+
+from app.auth.principal import Principal
+
+
+class AuthProvider(ABC):
+    """One authentication mechanism (API key, password/session, Stytch, ...).
+
+    A provider inspects the incoming request and returns a
+    :class:`~app.auth.principal.Principal` when it recognises the credential, or
+    ``None`` when the request is simply "not for me". It must **never** raise for
+    the not-me case — deciding whether an unauthenticated request is a 401 is the
+    resolver's job, made once across all providers. See
+    ``docs/design/API_CONTRACT.md`` §1.
+    """
+
+    @abstractmethod
+    async def authenticate(self, request: Request) -> Principal | None:
+        """Attempt to authenticate the request.
+
+        Args:
+            request: The incoming request to inspect for a credential.
+
+        Returns:
+            The resolved principal when this provider recognises and validates
+            the credential, otherwise ``None``.
+        """
+        raise NotImplementedError

--- a/app/auth/auth_registry.py
+++ b/app/auth/auth_registry.py
@@ -1,0 +1,34 @@
+"""An order-preserving registry of the enabled authentication providers."""
+
+from app.auth.auth_provider import AuthProvider
+
+
+class AuthRegistry:
+    """Holds the enabled :class:`~app.auth.auth_provider.AuthProvider` instances.
+
+    Registration order is preserved and is the order in which the resolver tries
+    providers. The registry is mutable and lives on ``app.state`` so a later lane
+    (R2's ``PasswordSessionProvider``) can register itself after the foundation
+    has wired the API-key provider — the resolver reads the registry live, so a
+    provider registered after the resolver was constructed still takes effect.
+    """
+
+    def __init__(self) -> None:
+        """Initialise an empty registry."""
+        self._providers: list[AuthProvider] = []
+
+    def register(self, provider: AuthProvider) -> None:
+        """Append a provider to the end of the try-order.
+
+        Args:
+            provider: The provider to enable.
+        """
+        self._providers.append(provider)
+
+    def providers(self) -> tuple[AuthProvider, ...]:
+        """Return the enabled providers in registration order."""
+        return tuple(self._providers)
+
+    def is_empty(self) -> bool:
+        """Return ``True`` when no provider is enabled."""
+        return not self._providers

--- a/app/auth/auth_resolver.py
+++ b/app/auth/auth_resolver.py
@@ -1,0 +1,80 @@
+"""Resolves a single principal per request across the enabled providers."""
+
+from fastapi import Request
+
+from app.auth.auth_registry import AuthRegistry
+from app.auth.principal import Principal
+from app.auth.principal_kind import PrincipalKind
+from app.auth.service_identity import ServiceIdentity
+from app.errors.unauthorized_error import UnauthorizedError
+
+
+class AuthResolver:
+    """Turns an enabled-provider registry into a single resolved principal.
+
+    Semantics (see ``docs/design/API_CONTRACT.md`` §1):
+
+    * **Auth not configured** — no auth mode selected and no API key set — return
+      a permissive anonymous ``service`` principal so an unconfigured deployment
+      (and the default test-suite) stays open. This is the backward-compatible
+      path.
+    * **Auth configured** — try each enabled provider in registration order and
+      return the first principal produced. If none match, the request carried no
+      valid credential and :class:`UnauthorizedError` (401) is raised.
+
+    ``auth_configured`` is the fail-closed signal and is deliberately **not** the
+    same as "the registry is non-empty": a mode can be configured before its
+    provider is wired (for example ``LAVS_AUTH_MODES=password`` while R2's
+    ``PasswordSessionProvider`` has not shipped). In that window every request
+    fails closed (401) rather than silently falling open. The registry is read
+    live on every resolve, so a provider registered after this resolver was
+    constructed (e.g. R2's provider) is honoured without rebuilding the resolver.
+    """
+
+    def __init__(self, registry: AuthRegistry, edition: str, auth_configured: bool) -> None:
+        """Initialise the resolver.
+
+        Args:
+            registry: The registry of enabled providers to consult.
+            edition: The edition stamped onto the anonymous principal.
+            auth_configured: Whether any authentication is configured for this
+                deployment (an auth mode is selected or an API key is set). When
+                ``True`` the resolver fails closed on an unauthenticated request.
+        """
+        self._registry = registry
+        self._edition = edition
+        self._auth_configured = auth_configured
+
+    async def resolve(self, request: Request) -> Principal:
+        """Resolve the caller's principal for a request.
+
+        Args:
+            request: The incoming request.
+
+        Returns:
+            The resolved principal (an anonymous service principal when auth is
+            not configured).
+
+        Raises:
+            UnauthorizedError: When auth is configured but no provider
+                authenticates the request.
+        """
+        providers = self._registry.providers()
+
+        for provider in providers:
+            principal = await provider.authenticate(request)
+            if principal is not None:
+                return principal
+
+        if self._auth_configured or providers:
+            raise UnauthorizedError(message="No valid credentials were provided.")
+
+        return self._anonymous_principal()
+
+    def _anonymous_principal(self) -> Principal:
+        """Build the permissive anonymous principal used when auth is off."""
+        return Principal(
+            kind=PrincipalKind.SERVICE,
+            id=ServiceIdentity.ANONYMOUS.value,
+            edition=self._edition,
+        )

--- a/app/auth/auth_resolver_factory.py
+++ b/app/auth/auth_resolver_factory.py
@@ -1,0 +1,63 @@
+"""Builds the auth registry and resolver from deployment settings.
+
+Centralising construction here keeps the wiring identical between the
+application lifespan (which stores the registry/resolver on ``app.state``) and
+the request-time fallback in :mod:`app.auth.require_principal` (used when no
+lifespan has run, e.g. a bare ``TestClient``). The API-key provider is enabled
+when a key is configured (``is_authentication_enabled``) or the ``apikey`` mode
+is explicitly listed in ``LAVS_AUTH_MODES``.
+"""
+
+from app.auth.auth_registry import AuthRegistry
+from app.auth.auth_resolver import AuthResolver
+from app.auth.auth_settings import AuthSettings
+from app.auth.providers.api_key_provider import ApiKeyProvider
+from app.security.api_key import is_authentication_enabled
+
+
+class AuthResolverFactory:
+    """Constructs the enabled-provider registry and its resolver."""
+
+    @staticmethod
+    def build_registry(settings: AuthSettings) -> AuthRegistry:
+        """Build a registry populated with the providers enabled by ``settings``.
+
+        Args:
+            settings: The deployment auth settings.
+
+        Returns:
+            A registry holding every provider the foundation enables. R2 extends
+            this by registering its password/session provider onto the returned
+            registry (typically via ``app.state.auth_registry``).
+        """
+        registry = AuthRegistry()
+
+        apikey_enabled = is_authentication_enabled() or settings.apikey_mode_enabled()
+        if apikey_enabled:
+            registry.register(ApiKeyProvider(edition=settings.edition()))
+
+        return registry
+
+    @staticmethod
+    def build_resolver(
+        settings: AuthSettings, registry: AuthRegistry | None = None
+    ) -> AuthResolver:
+        """Build a resolver over a registry (constructing one when not supplied).
+
+        Args:
+            settings: The deployment auth settings.
+            registry: An existing registry to resolve over; when ``None`` a fresh
+                registry is built from ``settings``.
+
+        Returns:
+            A resolver reading the (live) registry.
+        """
+        resolved_registry = (
+            registry if registry is not None else AuthResolverFactory.build_registry(settings)
+        )
+        auth_configured = bool(settings.modes()) or is_authentication_enabled()
+        return AuthResolver(
+            registry=resolved_registry,
+            edition=settings.edition(),
+            auth_configured=auth_configured,
+        )

--- a/app/auth/auth_settings.py
+++ b/app/auth/auth_settings.py
@@ -1,0 +1,114 @@
+"""Deployment configuration for the auth spine, read from the environment.
+
+Per project convention (see :mod:`app.security.api_key_settings`), fixed
+configuration is expressed through a settings class rather than bare
+module-level constants, and the environment is read on demand so values can
+change at runtime without re-importing. Every value may also be injected
+explicitly through the constructor, which the tests use to exercise a
+fully-configured (fail-closed) resolver without mutating the process
+environment.
+"""
+
+import os
+
+from app.auth.auth_mode import AuthMode
+
+
+class AuthSettings:
+    """Typed accessors over the ``LAVS_AUTH_*`` environment configuration."""
+
+    _MODES_ENV_VAR: str = "LAVS_AUTH_MODES"
+    _ALLOWED_DOMAINS_ENV_VAR: str = "LAVS_ALLOWED_EMAIL_DOMAINS"
+    _SESSION_TTL_ENV_VAR: str = "LAVS_SESSION_TTL_SECONDS"
+    _EDITION_ENV_VAR: str = "LAVS_EDITION"
+
+    _DEFAULT_SESSION_TTL_SECONDS: int = 604800
+    _DEFAULT_EDITION: str = "oss"
+
+    def __init__(
+        self,
+        modes: set[AuthMode] | None = None,
+        allowed_email_domains: tuple[str, ...] | None = None,
+        session_ttl_seconds: int | None = None,
+        edition: str | None = None,
+    ) -> None:
+        """Initialise the settings.
+
+        Any argument left as ``None`` is resolved from the environment on
+        access; a supplied argument overrides the environment entirely (used by
+        tests to construct a fully-configured resolver).
+
+        Args:
+            modes: The enabled authentication modes.
+            allowed_email_domains: The sign-up email-domain allow-list (empty
+                tuple means "allow all").
+            session_ttl_seconds: Session lifetime in seconds.
+            edition: The deployment edition label.
+        """
+        self._modes = modes
+        self._allowed_email_domains = allowed_email_domains
+        self._session_ttl_seconds = session_ttl_seconds
+        self._edition = edition
+
+    @staticmethod
+    def _split_csv(raw: str) -> list[str]:
+        """Split a comma-separated env value into trimmed, non-empty items."""
+        return [item.strip() for item in raw.split(",") if item.strip()]
+
+    def modes(self) -> set[AuthMode]:
+        """Return the set of enabled authentication modes.
+
+        Unrecognised tokens (for example a future ``stytch``) are ignored so a
+        forward-compatible config never crashes the foundation.
+        """
+        if self._modes is not None:
+            return set(self._modes)
+
+        raw = os.environ.get(self._MODES_ENV_VAR, "")
+        recognised: set[AuthMode] = set()
+        valid_values = {mode.value for mode in AuthMode}
+        for token in self._split_csv(raw):
+            lowered = token.lower()
+            if lowered in valid_values:
+                recognised.add(AuthMode(lowered))
+        return recognised
+
+    def allowed_email_domains(self) -> tuple[str, ...]:
+        """Return the sign-up email-domain allow-list.
+
+        An empty tuple means every domain is allowed. Domains are lower-cased so
+        the allow-list check is case-insensitive.
+        """
+        if self._allowed_email_domains is not None:
+            return self._allowed_email_domains
+
+        raw = os.environ.get(self._ALLOWED_DOMAINS_ENV_VAR, "")
+        return tuple(item.lower() for item in self._split_csv(raw))
+
+    def session_ttl_seconds(self) -> int:
+        """Return the session lifetime in seconds."""
+        if self._session_ttl_seconds is not None:
+            return self._session_ttl_seconds
+
+        raw = os.environ.get(self._SESSION_TTL_ENV_VAR)
+        if raw is None or not raw.strip():
+            return self._DEFAULT_SESSION_TTL_SECONDS
+        return int(raw)
+
+    def edition(self) -> str:
+        """Return the deployment edition label (defaults to ``oss``)."""
+        if self._edition is not None:
+            return self._edition
+
+        raw = os.environ.get(self._EDITION_ENV_VAR)
+        if raw is None or not raw.strip():
+            return self._DEFAULT_EDITION
+        return raw.strip()
+
+    def password_enabled(self) -> bool:
+        """Return ``True`` when the ``password`` mode is enabled."""
+        return AuthMode.PASSWORD in self.modes()
+
+    def apikey_mode_enabled(self) -> bool:
+        """Return ``True`` when the ``apikey`` mode is explicitly enabled."""
+        return AuthMode.APIKEY in self.modes()

--- a/app/auth/password_hasher.py
+++ b/app/auth/password_hasher.py
@@ -1,0 +1,54 @@
+"""Argon2id password hashing and verification.
+
+Wraps :class:`argon2.PasswordHasher`, which uses the ``argon2id`` variant by
+default — the memory-hard, side-channel-resistant algorithm mandated by the
+project's security invariants. Plaintext passwords are never stored: only the
+self-describing argon2 hash string (which embeds its own salt and parameters) is
+persisted, and verification is constant-time within the argon2 implementation.
+The cost parameters are argon2's vetted defaults rather than bare local
+constants.
+"""
+
+from argon2 import PasswordHasher as Argon2PasswordHasher
+from argon2.exceptions import VerifyMismatchError
+
+
+class PasswordHasher:
+    """Hash and verify passwords with argon2id."""
+
+    def __init__(self, hasher: Argon2PasswordHasher | None = None) -> None:
+        """Initialise the hasher.
+
+        Args:
+            hasher: An optional pre-configured argon2 hasher. Defaults to a
+                fresh :class:`argon2.PasswordHasher` using argon2's vetted
+                default cost parameters.
+        """
+        self._hasher = hasher if hasher is not None else Argon2PasswordHasher()
+
+    def hash_password(self, password: str) -> str:
+        """Hash a plaintext password.
+
+        Args:
+            password: The plaintext password.
+
+        Returns:
+            The self-describing argon2id hash string (salt + parameters
+            embedded). Never the plaintext.
+        """
+        return self._hasher.hash(password)
+
+    def verify_password(self, password_hash: str, password: str) -> bool:
+        """Verify a plaintext password against a stored argon2 hash.
+
+        Args:
+            password_hash: The stored argon2id hash string.
+            password: The plaintext password to check.
+
+        Returns:
+            ``True`` when the password matches, ``False`` on mismatch.
+        """
+        try:
+            return self._hasher.verify(password_hash, password)
+        except VerifyMismatchError:
+            return False

--- a/app/auth/principal.py
+++ b/app/auth/principal.py
@@ -1,0 +1,21 @@
+"""The resolved caller identity injected into every protected route."""
+
+from pydantic import BaseModel
+
+from app.auth.principal_kind import PrincipalKind
+
+
+class Principal(BaseModel):
+    """The authenticated caller, as resolved by the auth spine.
+
+    Mirrors the contract's ``Principal = {kind, id, email?, edition}`` (see
+    ``docs/design/API_CONTRACT.md`` §1). Resource routes depend on a resolved
+    principal without caring which provider produced it, which is exactly what
+    lets new providers (password/session, Stytch) be added without touching the
+    routes.
+    """
+
+    kind: PrincipalKind
+    id: str
+    email: str | None = None
+    edition: str

--- a/app/auth/principal_kind.py
+++ b/app/auth/principal_kind.py
@@ -1,0 +1,14 @@
+"""The kind of identity a resolved :class:`~app.auth.principal.Principal` carries."""
+
+from enum import StrEnum
+
+
+class PrincipalKind(StrEnum):
+    """Whether a principal is a human ``user`` or a machine ``service``.
+
+    See ``docs/design/API_CONTRACT.md`` §1 — password/session logins resolve to
+    ``user`` principals; API-key (headless) callers resolve to ``service``.
+    """
+
+    USER = "user"
+    SERVICE = "service"

--- a/app/auth/providers/__init__.py
+++ b/app/auth/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Concrete :class:`~app.auth.auth_provider.AuthProvider` implementations."""

--- a/app/auth/providers/api_key_provider.py
+++ b/app/auth/providers/api_key_provider.py
@@ -1,0 +1,58 @@
+"""Provider that authenticates the headless ``X-API-Key`` credential."""
+
+import hmac
+
+from fastapi import Request
+
+from app.auth.auth_provider import AuthProvider
+from app.auth.principal import Principal
+from app.auth.principal_kind import PrincipalKind
+from app.auth.service_identity import ServiceIdentity
+from app.security.api_key import API_KEY_HEADER, get_configured_api_key
+
+
+class ApiKeyProvider(AuthProvider):
+    """Authenticate a request by its ``X-API-Key`` header.
+
+    Wraps the existing :mod:`app.security.api_key` configuration: it reads the
+    header name and configured key from there and compares them with a
+    constant-time comparison (:func:`hmac.compare_digest`) so a wrong key cannot
+    be discovered by timing. On a match it mints a ``service`` principal; on any
+    mismatch (or no configured key, or no header) it returns ``None`` and lets
+    another provider — or the resolver's 401 — decide the request.
+    """
+
+    def __init__(self, edition: str) -> None:
+        """Initialise the provider.
+
+        Args:
+            edition: The edition stamped onto the resolved service principal.
+        """
+        self._edition = edition
+
+    async def authenticate(self, request: Request) -> Principal | None:
+        """Authenticate the request via its API-key header.
+
+        Args:
+            request: The incoming request.
+
+        Returns:
+            A ``service`` principal when the header matches the configured key,
+            otherwise ``None``.
+        """
+        configured_key = get_configured_api_key()
+        if configured_key is None or configured_key == "":
+            return None
+
+        presented_key = request.headers.get(API_KEY_HEADER)
+        if presented_key is None:
+            return None
+
+        if not hmac.compare_digest(presented_key, configured_key):
+            return None
+
+        return Principal(
+            kind=PrincipalKind.SERVICE,
+            id=ServiceIdentity.API_KEY.value,
+            edition=self._edition,
+        )

--- a/app/auth/providers/password_session_provider.py
+++ b/app/auth/providers/password_session_provider.py
@@ -1,0 +1,74 @@
+"""Provider that authenticates a browser via the ``lavs_session`` cookie."""
+
+import duckdb
+from fastapi import Request
+
+from app.auth.auth_provider import AuthProvider
+from app.auth.principal import Principal
+from app.auth.principal_kind import PrincipalKind
+from app.auth.session.session_cookie import SessionCookie
+from app.auth.session.session_service import SessionService
+from app.auth.users.user_repository import UserRepository
+
+
+class PasswordSessionProvider(AuthProvider):
+    """Authenticate a request by its ``lavs_session`` session cookie.
+
+    Reads the cookie, looks up a live (unexpired) session by the token's hash,
+    and — on a hit — mints a ``user`` principal for the owning account. On any
+    miss (no cookie, unknown/expired session, vanished user, or no live
+    database) it returns ``None`` so another provider, or the resolver's 401,
+    decides the request. It never raises for the not-me case.
+    """
+
+    def __init__(
+        self,
+        edition: str,
+        session_service: SessionService | None = None,
+        user_repository: UserRepository | None = None,
+    ) -> None:
+        """Initialise the provider.
+
+        Args:
+            edition: The edition stamped onto the resolved user principal.
+            session_service: The session store. Defaults to a fresh
+                :class:`~app.auth.session.session_service.SessionService`.
+            user_repository: The user store. Defaults to a fresh
+                :class:`~app.auth.users.user_repository.UserRepository`.
+        """
+        self._edition = edition
+        self._session_service = session_service if session_service is not None else SessionService()
+        self._user_repository = user_repository if user_repository is not None else UserRepository()
+
+    async def authenticate(self, request: Request) -> Principal | None:
+        """Authenticate the request via its session cookie.
+
+        Args:
+            request: The incoming request.
+
+        Returns:
+            A ``user`` principal when the cookie names a live session for an
+            existing user, otherwise ``None``.
+        """
+        token = request.cookies.get(SessionCookie.NAME)
+        if token is None or token == "":
+            return None
+
+        connection: duckdb.DuckDBPyConnection | None = request.app.state.db_connection
+        if connection is None:
+            return None
+
+        user_id = self._session_service.lookup_active_user_id(connection, token)
+        if user_id is None:
+            return None
+
+        user_row = await self._user_repository.get_user_by_id(connection, user_id)
+        if user_row is None:
+            return None
+
+        return Principal(
+            kind=PrincipalKind.USER,
+            id=user_id,
+            email=str(user_row[1]),
+            edition=self._edition,
+        )

--- a/app/auth/require_principal.py
+++ b/app/auth/require_principal.py
@@ -1,0 +1,59 @@
+"""FastAPI dependency that resolves the request's principal.
+
+Resource routers depend on this to enforce authentication uniformly. It reads
+the application-managed :class:`~app.auth.auth_resolver.AuthResolver` from
+``app.state`` (created in the lifespan). When no resolver is present — for
+example a bare ``TestClient`` whose lifespan did not run — it falls back to a
+resolver built from the current environment, which stays open when nothing is
+configured and fail-closed when it is. This mirrors how the DB dependency and
+query layer tolerate a lifespan-less ``app.state``.
+"""
+
+from typing import Annotated
+
+from fastapi import Depends, Request
+
+from app.auth.auth_resolver import AuthResolver
+from app.auth.auth_resolver_factory import AuthResolverFactory
+from app.auth.auth_settings import AuthSettings
+from app.auth.principal import Principal
+
+
+def _resolver_for(request: Request) -> AuthResolver:
+    """Return the resolver to use for a request.
+
+    Prefers the application-managed resolver on ``app.state``; falls back to an
+    environment-built resolver when the app was started without a lifespan.
+
+    Args:
+        request: The incoming request.
+
+    Returns:
+        The resolver to authenticate with.
+    """
+    state = request.app.state
+    resolver = state.auth_resolver if hasattr(state, "auth_resolver") else None
+    if resolver is None:
+        return AuthResolverFactory.build_resolver(AuthSettings())
+    return resolver
+
+
+async def require_principal(request: Request) -> Principal:
+    """Resolve and return the authenticated principal for the request.
+
+    Args:
+        request: The incoming request.
+
+    Returns:
+        The resolved :class:`~app.auth.principal.Principal`.
+
+    Raises:
+        UnauthorizedError: When auth is configured but no provider authenticates
+            the request.
+    """
+    resolver = _resolver_for(request)
+    return await resolver.resolve(request)
+
+
+PrincipalDep = Annotated[Principal, Depends(require_principal)]
+"""Dependency alias injecting the resolved principal into a route."""

--- a/app/auth/service_identity.py
+++ b/app/auth/service_identity.py
@@ -1,0 +1,14 @@
+"""Stable identifiers for the non-human (``service``) principals LAVS mints."""
+
+from enum import StrEnum
+
+
+class ServiceIdentity(StrEnum):
+    """The fixed ``id`` values carried by service principals.
+
+    Kept as an enum rather than bare string literals so the anonymous and
+    API-key identities are named in exactly one place.
+    """
+
+    ANONYMOUS = "anonymous"
+    API_KEY = "api-key"

--- a/app/auth/session/__init__.py
+++ b/app/auth/session/__init__.py
@@ -1,0 +1,7 @@
+"""Password-session support: cookie configuration and the session store.
+
+Owned by the R2 login lane. Sessions are opaque, high-entropy tokens minted by
+:class:`~app.auth.token_service.TokenService`, handed to the client once, and
+persisted **only** as their SHA-256 hash with a TTL expiry — a database leak
+therefore never yields a usable session token.
+"""

--- a/app/auth/session/session_cookie.py
+++ b/app/auth/session/session_cookie.py
@@ -1,0 +1,20 @@
+"""Fixed configuration for the browser session cookie.
+
+Per project convention, fixed values live in a named config object rather than
+as bare string literals scattered across the login/logout/provider code, so the
+cookie's name and security attributes are declared in exactly one place. The
+attributes encode the security invariants: ``HttpOnly`` (no JavaScript access),
+``Secure`` (HTTPS only), and ``SameSite=Lax`` (CSRF mitigation).
+"""
+
+from typing import Literal
+
+
+class SessionCookie:
+    """The name and security attributes of the ``lavs_session`` cookie."""
+
+    NAME: str = "lavs_session"
+    PATH: str = "/"
+    SAME_SITE: Literal["lax"] = "lax"
+    HTTP_ONLY: bool = True
+    SECURE: bool = True

--- a/app/auth/session/session_service.py
+++ b/app/auth/session/session_service.py
@@ -1,0 +1,82 @@
+"""Create, look up, and revoke rows in the ``sessions`` table.
+
+A session is an opaque high-entropy token: :meth:`SessionService.create_session`
+mints one, stores only its SHA-256 hash together with a TTL-derived
+``expires_at``, and returns the **raw** token for the client's cookie. Lookups
+present the raw token, which is re-hashed and matched against the stored hash;
+an expired row never matches, so a lapsed cookie authenticates nobody. Every
+statement binds its values through ``?`` placeholders.
+"""
+
+from datetime import datetime, timedelta
+
+import duckdb
+
+from app.auth.token_service import TokenService
+from app.models.types.ulid_id import new_ulid
+
+
+class SessionService:
+    """Persistence for opaque, hashed, TTL-expiring session tokens."""
+
+    def __init__(self, token_service: TokenService | None = None) -> None:
+        """Initialise the service.
+
+        Args:
+            token_service: The token minting/hashing service. Defaults to a
+                fresh :class:`~app.auth.token_service.TokenService`.
+        """
+        self._token_service = token_service if token_service is not None else TokenService()
+
+    def create_session(
+        self, conn: duckdb.DuckDBPyConnection, user_id: str, ttl_seconds: int
+    ) -> str:
+        """Mint a session for a user and return its raw token.
+
+        Args:
+            conn: The live DuckDB connection.
+            user_id: The id of the user the session belongs to.
+            ttl_seconds: The session lifetime in seconds.
+
+        Returns:
+            The raw, high-entropy session token (store only its hash — this is
+            the value handed to the client cookie and never persisted).
+        """
+        token = self._token_service.generate_token()
+        token_hash = self._token_service.hash_token(token)
+        expires_at = datetime.now() + timedelta(seconds=ttl_seconds)
+        conn.execute(
+            "INSERT INTO sessions (id, user_id, token_hash, expires_at) VALUES (?, ?, ?, ?)",
+            [new_ulid(), user_id, token_hash, expires_at],
+        )
+        return token
+
+    def lookup_active_user_id(self, conn: duckdb.DuckDBPyConnection, token: str) -> str | None:
+        """Return the user id of a live (unexpired) session, or ``None``.
+
+        Args:
+            conn: The live DuckDB connection.
+            token: The raw token presented by the client.
+
+        Returns:
+            The owning user's id when a matching, unexpired session exists,
+            otherwise ``None`` (unknown token or expired session).
+        """
+        token_hash = self._token_service.hash_token(token)
+        row = conn.execute(
+            "SELECT user_id FROM sessions WHERE token_hash = ? AND expires_at > ?",
+            [token_hash, datetime.now()],
+        ).fetchone()
+        if row is None:
+            return None
+        return str(row[0])
+
+    def delete_session(self, conn: duckdb.DuckDBPyConnection, token: str) -> None:
+        """Revoke a session by deleting its row (idempotent).
+
+        Args:
+            conn: The live DuckDB connection.
+            token: The raw token whose session should be revoked.
+        """
+        token_hash = self._token_service.hash_token(token)
+        conn.execute("DELETE FROM sessions WHERE token_hash = ?", [token_hash])

--- a/app/auth/signup/__init__.py
+++ b/app/auth/signup/__init__.py
@@ -1,0 +1,7 @@
+"""Password sign-up and email-verification lane (R1).
+
+Owns the ``POST /auth/signup`` and ``POST /auth/verify`` flows: domain
+allow-list enforcement, duplicate-email conflict handling, argon2id password
+hashing, and the issue/consume lifecycle of single-use, hashed, expiring email
+verification tokens. See ``docs/design/API_CONTRACT.md`` §2.
+"""

--- a/app/auth/signup/signup_policy.py
+++ b/app/auth/signup/signup_policy.py
@@ -1,0 +1,21 @@
+"""Fixed sign-up input policy (email shape and password strength).
+
+Centralises the sign-up validation constants in one named place rather than
+scattering magic literals across the request model, so the pattern and the
+minimum password length live in exactly one location.
+"""
+
+
+class SignupPolicy:
+    """Named constants governing sign-up input validation."""
+
+    MIN_PASSWORD_LENGTH: int = 12
+    """Minimum accepted plaintext password length (characters)."""
+
+    EMAIL_PATTERN: str = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
+    """A deliberately conservative ``local@domain.tld`` shape check.
+
+    Full RFC-5322 validation would require the ``email-validator`` dependency
+    (not installed); this rejects the obviously malformed while normalisation
+    lower-cases the value so the domain allow-list check is case-insensitive.
+    """

--- a/app/auth/signup/signup_service.py
+++ b/app/auth/signup/signup_service.py
@@ -1,0 +1,149 @@
+"""Orchestrates the ``POST /auth/signup`` flow.
+
+Security posture:
+- The password is only ever stored as an argon2id hash (never plaintext).
+- The verification token is high-entropy, stored **hashed**, expiring, and
+  single-use; only the raw token leaves the process, via the mailer.
+- Beyond the contract-mandated 409 on an existing address, the response reveals
+  nothing about account existence (no enumeration).
+"""
+
+import duckdb
+
+from app.auth.auth_settings import AuthSettings
+from app.auth.password_hasher import PasswordHasher
+from app.auth.signup.verification_email import VerificationEmail
+from app.auth.signup.verification_settings import VerificationSettings
+from app.auth.signup.verification_token_repository import VerificationTokenRepository
+from app.auth.token_service import TokenService
+from app.auth.users.user_repository import UserRepository
+from app.auth.users.user_status import UserStatus
+from app.errors.conflict_error import ConflictError
+from app.errors.domain_not_allowed_error import DomainNotAllowedError
+from app.mail.mailer import Mailer
+from app.models.requests.signup_model import SignupModel
+from app.models.types.ulid_id import new_ulid
+
+
+class SignupService:
+    """Register a pending user and issue an email verification token."""
+
+    def __init__(
+        self,
+        users: UserRepository | None = None,
+        password_hasher: PasswordHasher | None = None,
+        token_service: TokenService | None = None,
+        verification_tokens: VerificationTokenRepository | None = None,
+        verification_email: VerificationEmail | None = None,
+        verification_settings: VerificationSettings | None = None,
+    ) -> None:
+        """Initialise the service with its collaborators.
+
+        Every collaborator defaults to a fresh, stateless instance; tests may
+        inject fakes or pinned settings.
+
+        Args:
+            users: The users-table repository.
+            password_hasher: The argon2id password hasher.
+            token_service: The high-entropy token mint/hash service.
+            verification_tokens: The verification-token repository.
+            verification_email: The verification email renderer.
+            verification_settings: The verification-token lifetime settings.
+        """
+        self._users = users if users is not None else UserRepository()
+        self._password_hasher = password_hasher if password_hasher is not None else PasswordHasher()
+        self._token_service = token_service if token_service is not None else TokenService()
+        self._verification_tokens = (
+            verification_tokens
+            if verification_tokens is not None
+            else VerificationTokenRepository()
+        )
+        self._verification_email = (
+            verification_email if verification_email is not None else VerificationEmail()
+        )
+        self._verification_settings = (
+            verification_settings if verification_settings is not None else VerificationSettings()
+        )
+
+    async def register(
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        mailer: Mailer,
+        model: SignupModel,
+        settings: AuthSettings,
+    ) -> None:
+        """Register a pending user and email them a verification token.
+
+        Args:
+            conn: The live DuckDB connection.
+            mailer: The transport used to deliver the raw token.
+            model: The validated (already normalised) sign-up body.
+            settings: The auth settings supplying the domain allow-list and
+                deployment edition.
+
+        Raises:
+            DomainNotAllowedError: When the email's domain is not allow-listed.
+            ConflictError: When a user with that email already exists.
+        """
+        email = model.email
+        self._assert_domain_allowed(email, settings)
+        await self._assert_email_available(conn, email)
+
+        password_hash = self._password_hasher.hash_password(model.password)
+        user_id = new_ulid()
+        await self._users.create_user(
+            conn,
+            user_id=user_id,
+            email=email,
+            password_hash=password_hash,
+            status=UserStatus.PENDING,
+            edition=settings.edition(),
+        )
+
+        raw_token = self._token_service.generate_token()
+        await self._verification_tokens.issue(
+            conn,
+            token_hash=self._token_service.hash_token(raw_token),
+            user_id=user_id,
+            ttl_seconds=self._verification_settings.ttl_seconds(),
+        )
+
+        mailer.send(
+            to=email,
+            subject=self._verification_email.subject(),
+            body=self._verification_email.body(raw_token),
+        )
+
+    def _assert_domain_allowed(self, email: str, settings: AuthSettings) -> None:
+        """Raise when a non-empty allow-list excludes the email's domain.
+
+        Args:
+            email: The normalised (lower-cased) email address.
+            settings: The auth settings carrying the allow-list.
+
+        Raises:
+            DomainNotAllowedError: When the domain is not permitted.
+        """
+        allowed = settings.allowed_email_domains()
+        if not allowed:
+            return
+        domain = email.rsplit("@", 1)[-1]
+        if domain not in allowed:
+            raise DomainNotAllowedError(
+                message="This email domain is not permitted for sign-up.",
+                details={"domain": domain},
+            )
+
+    async def _assert_email_available(self, conn: duckdb.DuckDBPyConnection, email: str) -> None:
+        """Raise a generic conflict when the email is already registered.
+
+        Args:
+            conn: The live DuckDB connection.
+            email: The normalised email address.
+
+        Raises:
+            ConflictError: When a user with that email already exists.
+        """
+        existing = await self._users.get_user_by_email(conn, email)
+        if existing is not None:
+            raise ConflictError(message="This email address cannot be registered.")

--- a/app/auth/signup/signup_status.py
+++ b/app/auth/signup/signup_status.py
@@ -1,0 +1,14 @@
+"""The accepted-sign-up status returned by ``POST /auth/signup``."""
+
+from enum import StrEnum
+
+
+class SignupStatus(StrEnum):
+    """The ``status`` field of the 202 sign-up acknowledgement.
+
+    A single member today (``pending_verification``); modelled as an enum so the
+    wire value lives in one place rather than as a bare string literal in the
+    route and the response model.
+    """
+
+    PENDING_VERIFICATION = "pending_verification"

--- a/app/auth/signup/verification_email.py
+++ b/app/auth/signup/verification_email.py
@@ -1,0 +1,33 @@
+"""Builds the transactional email carrying a raw verification token.
+
+The template lives here (one named place) so the subject/body copy is not a
+magic literal embedded in the sign-up service. Only the **raw** token is placed
+in the body; its hash is what the database stores.
+"""
+
+
+class VerificationEmail:
+    """Renders the subject and body of a verification email for a token."""
+
+    _SUBJECT: str = "Verify your LAVS account"
+    _BODY_TEMPLATE: str = (
+        "Welcome to LAVS.\n\n"
+        "Use the following single-use token to verify your account:\n\n"
+        "{token}\n\n"
+        "The token expires; if it has, request a new one by signing up again."
+    )
+
+    def subject(self) -> str:
+        """Return the verification email subject line."""
+        return self._SUBJECT
+
+    def body(self, token: str) -> str:
+        """Return the verification email body embedding the raw token.
+
+        Args:
+            token: The raw (unhashed) verification token to deliver.
+
+        Returns:
+            The rendered plain-text email body.
+        """
+        return self._BODY_TEMPLATE.format(token=token)

--- a/app/auth/signup/verification_service.py
+++ b/app/auth/signup/verification_service.py
@@ -1,0 +1,85 @@
+"""Orchestrates the ``POST /auth/verify`` flow.
+
+Consumes a verification token, activates the user, and returns the safe user
+projection. The presented token is hashed before lookup (constant-time equality
+over high-entropy digests), matched only while unconsumed and unexpired, and
+stamped consumed so it is strictly single-use. Any miss — unknown, expired, or
+already-consumed — yields the same generic failure so nothing about token or
+account state leaks.
+"""
+
+import duckdb
+
+from app.auth.signup.verification_token_repository import VerificationTokenRepository
+from app.auth.token_service import TokenService
+from app.auth.users.user_repository import UserRepository
+from app.errors.not_found_error import NotFoundError
+from app.models.requests.verify_model import VerifyModel
+from app.models.responses.user_response_model import UserResponseModel
+
+
+class VerificationService:
+    """Verify an email token and activate the corresponding user."""
+
+    _EMAIL_INDEX: int = 1
+    _STATUS_INDEX: int = 3
+    _EDITION_INDEX: int = 4
+    _USER_ID_INDEX: int = 1
+
+    def __init__(
+        self,
+        users: UserRepository | None = None,
+        token_service: TokenService | None = None,
+        verification_tokens: VerificationTokenRepository | None = None,
+    ) -> None:
+        """Initialise the service with its collaborators.
+
+        Args:
+            users: The users-table repository.
+            token_service: The token hashing service.
+            verification_tokens: The verification-token repository.
+        """
+        self._users = users if users is not None else UserRepository()
+        self._token_service = token_service if token_service is not None else TokenService()
+        self._verification_tokens = (
+            verification_tokens
+            if verification_tokens is not None
+            else VerificationTokenRepository()
+        )
+
+    async def verify(
+        self, conn: duckdb.DuckDBPyConnection, model: VerifyModel
+    ) -> UserResponseModel:
+        """Consume the token, activate the user, and return the user model.
+
+        Args:
+            conn: The live DuckDB connection.
+            model: The validated verify body carrying the raw token.
+
+        Returns:
+            The activated user as a safe :class:`UserResponseModel`.
+
+        Raises:
+            NotFoundError: When the token is unknown, expired, or already used
+                (a single generic failure — no enumeration).
+        """
+        token_hash = self._token_service.hash_token(model.token)
+        token_row = await self._verification_tokens.find_active(conn, token_hash)
+        if token_row is None:
+            raise NotFoundError(message="The verification token is invalid or has expired.")
+
+        user_id = str(token_row[self._USER_ID_INDEX])
+        await self._users.activate_user(conn, user_id)
+        await self._verification_tokens.consume(conn, token_hash)
+
+        user_row = await self._users.get_user_by_id(conn, user_id)
+        if user_row is None:
+            raise NotFoundError(message="The verification token is invalid or has expired.")
+
+        edition = user_row[self._EDITION_INDEX]
+        return UserResponseModel(
+            id=user_id,
+            email=str(user_row[self._EMAIL_INDEX]),
+            status=str(user_row[self._STATUS_INDEX]),
+            edition=str(edition) if edition is not None else None,
+        )

--- a/app/auth/signup/verification_settings.py
+++ b/app/auth/signup/verification_settings.py
@@ -1,0 +1,36 @@
+"""Deployment configuration for the email-verification token lifetime.
+
+Mirrors :class:`~app.auth.auth_settings.AuthSettings`: fixed configuration is
+expressed through a settings class read from the environment on demand, and
+every value may be injected through the constructor so tests can pin a lifetime
+without mutating the process environment.
+"""
+
+import os
+
+
+class VerificationSettings:
+    """Typed accessor over the email-verification token lifetime configuration."""
+
+    _TTL_ENV_VAR: str = "LAVS_EMAIL_VERIFICATION_TTL_SECONDS"
+    _DEFAULT_TTL_SECONDS: int = 86400
+
+    def __init__(self, ttl_seconds: int | None = None) -> None:
+        """Initialise the settings.
+
+        Args:
+            ttl_seconds: The verification-token lifetime in seconds. When left
+                as ``None`` it is resolved from the environment on access,
+                defaulting to one day.
+        """
+        self._ttl_seconds = ttl_seconds
+
+    def ttl_seconds(self) -> int:
+        """Return the verification-token lifetime in seconds."""
+        if self._ttl_seconds is not None:
+            return self._ttl_seconds
+
+        raw = os.environ.get(self._TTL_ENV_VAR)
+        if raw is None or not raw.strip():
+            return self._DEFAULT_TTL_SECONDS
+        return int(raw)

--- a/app/auth/signup/verification_token_repository.py
+++ b/app/auth/signup/verification_token_repository.py
@@ -1,0 +1,78 @@
+"""Parameterized persistence for the ``email_verification_tokens`` table.
+
+Tokens are stored **only** as their SHA-256 hash (the raw token is never
+persisted), carry a DB-computed expiry, and are single-use: a consumed row is
+stamped with ``consumed_at`` and never matched again. Every statement binds its
+values through ``?`` placeholders — never string interpolation. Wall-clock time
+is taken from the database (``CURRENT_TIMESTAMP``) rather than the process so
+issuance and expiry share one clock.
+"""
+
+import duckdb
+
+
+class VerificationTokenRepository:
+    """Issue, look up, and consume email verification tokens."""
+
+    async def issue(
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        token_hash: str,
+        user_id: str,
+        ttl_seconds: int,
+    ) -> None:
+        """Insert a verification-token row with a DB-computed expiry.
+
+        Args:
+            conn: The live DuckDB connection.
+            token_hash: The SHA-256 hex digest of the raw token (never the raw
+                token itself).
+            user_id: The id of the pending user the token verifies.
+            ttl_seconds: The token lifetime, added to the DB clock for expiry.
+        """
+        conn.execute(
+            "INSERT INTO email_verification_tokens "
+            "(token_hash, user_id, expires_at, consumed_at) "
+            "VALUES (?, ?, CAST(CURRENT_TIMESTAMP AS TIMESTAMP) + "
+            "(? * INTERVAL 1 SECOND), NULL)",
+            [token_hash, user_id, ttl_seconds],
+        )
+
+    async def find_active(
+        self, conn: duckdb.DuckDBPyConnection, token_hash: str
+    ) -> tuple[object, ...] | None:
+        """Return an unconsumed, unexpired token row, or ``None``.
+
+        The match is by stored hash (the presented token is hashed before this
+        call), so a database leak of hashes cannot yield a usable token and the
+        equality is over high-entropy digests.
+
+        Args:
+            conn: The live DuckDB connection.
+            token_hash: The SHA-256 hex digest of the presented token.
+
+        Returns:
+            ``(token_hash, user_id, expires_at, consumed_at)`` when a live token
+            matches, otherwise ``None``.
+        """
+        return conn.execute(
+            "SELECT token_hash, user_id, expires_at, consumed_at "
+            "FROM email_verification_tokens "
+            "WHERE token_hash = ? AND consumed_at IS NULL "
+            "AND expires_at > CAST(CURRENT_TIMESTAMP AS TIMESTAMP)",
+            [token_hash],
+        ).fetchone()
+
+    async def consume(self, conn: duckdb.DuckDBPyConnection, token_hash: str) -> None:
+        """Mark a token consumed so it can never be used again.
+
+        Args:
+            conn: The live DuckDB connection.
+            token_hash: The SHA-256 hex digest of the token to retire.
+        """
+        conn.execute(
+            "UPDATE email_verification_tokens "
+            "SET consumed_at = CAST(CURRENT_TIMESTAMP AS TIMESTAMP) "
+            "WHERE token_hash = ?",
+            [token_hash],
+        )

--- a/app/auth/token_service.py
+++ b/app/auth/token_service.py
@@ -1,0 +1,61 @@
+"""High-entropy token generation, hashing, and constant-time comparison.
+
+Session and email-verification tokens are minted with :mod:`secrets` and are
+**only ever stored hashed** (SHA-256 hex): the raw token is handed to the client
+once and never persisted, so a database leak cannot yield a usable token.
+Lookups compare the SHA-256 of a presented token against the stored hash with
+:func:`hmac.compare_digest` so verification is constant-time.
+"""
+
+import hashlib
+import hmac
+import secrets
+
+
+class TokenService:
+    """Mint, hash, and compare opaque high-entropy tokens."""
+
+    _DEFAULT_ENTROPY_BYTES: int = 32
+
+    def __init__(self, entropy_bytes: int | None = None) -> None:
+        """Initialise the service.
+
+        Args:
+            entropy_bytes: Number of random bytes backing each generated token.
+                Defaults to 32 (256 bits) of entropy.
+        """
+        self._entropy_bytes = (
+            entropy_bytes if entropy_bytes is not None else self._DEFAULT_ENTROPY_BYTES
+        )
+
+    def generate_token(self) -> str:
+        """Generate a fresh URL-safe, high-entropy token.
+
+        Returns:
+            A cryptographically random token string (the raw secret — store only
+            its :meth:`hash_token`).
+        """
+        return secrets.token_urlsafe(self._entropy_bytes)
+
+    def hash_token(self, token: str) -> str:
+        """Return the SHA-256 hex digest of a token (the stored form).
+
+        Args:
+            token: The raw token.
+
+        Returns:
+            The 64-character hex SHA-256 digest.
+        """
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    def compare(self, token: str, token_hash: str) -> bool:
+        """Constant-time check that a raw token hashes to a stored digest.
+
+        Args:
+            token: The raw token presented by the client.
+            token_hash: The stored SHA-256 hex digest to compare against.
+
+        Returns:
+            ``True`` when the token matches the stored hash.
+        """
+        return hmac.compare_digest(self.hash_token(token), token_hash)

--- a/app/auth/users/__init__.py
+++ b/app/auth/users/__init__.py
@@ -1,0 +1,6 @@
+"""Shared user persistence for the password-auth lanes.
+
+Owned by the foundation because both the sign-up/verify lane (R1) and the
+login/session lane (R2) read and write the ``users`` table. Password hashes are
+persisted here but never surfaced in the response model.
+"""

--- a/app/auth/users/user_repository.py
+++ b/app/auth/users/user_repository.py
@@ -1,0 +1,93 @@
+"""Parameterized persistence for the shared ``users`` table."""
+
+import duckdb
+
+from app.auth.users.user_status import UserStatus
+from app.models.responses.user_response_model import UserResponseModel
+
+
+class UserRepository:
+    """Create, read, and activate rows in the ``users`` table.
+
+    Every statement binds its values through ``?`` placeholders (never string
+    interpolation). Read methods return the raw row (including ``password_hash``)
+    so the login lane can verify a password; :meth:`create_user` returns the
+    safe :class:`UserResponseModel`, which never carries the hash.
+    """
+
+    async def create_user(
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        user_id: str,
+        email: str,
+        password_hash: str,
+        status: UserStatus,
+        edition: str | None,
+    ) -> UserResponseModel:
+        """Insert a new user and return its safe response model.
+
+        Args:
+            conn: The live DuckDB connection.
+            user_id: The user's ULID identifier.
+            email: The user's unique email address.
+            password_hash: The argon2id hash of the user's password.
+            status: The initial lifecycle status.
+            edition: The edition the user was created under (nullable).
+
+        Returns:
+            The created user as a :class:`UserResponseModel` (no password hash).
+        """
+        conn.execute(
+            "INSERT INTO users (id, email, password_hash, status, edition) VALUES (?, ?, ?, ?, ?)",
+            [user_id, email, password_hash, status.value, edition],
+        )
+        return UserResponseModel(id=user_id, email=email, status=status.value, edition=edition)
+
+    async def get_user_by_email(
+        self, conn: duckdb.DuckDBPyConnection, email: str
+    ) -> tuple[object, ...] | None:
+        """Return the raw user row for an email, or ``None`` when absent.
+
+        Args:
+            conn: The live DuckDB connection.
+            email: The email to look up.
+
+        Returns:
+            ``(id, email, password_hash, status, edition, created_at)`` or
+            ``None``.
+        """
+        return conn.execute(
+            "SELECT id, email, password_hash, status, edition, created_at "
+            "FROM users WHERE email = ?",
+            [email],
+        ).fetchone()
+
+    async def get_user_by_id(
+        self, conn: duckdb.DuckDBPyConnection, user_id: str
+    ) -> tuple[object, ...] | None:
+        """Return the raw user row for an id, or ``None`` when absent.
+
+        Args:
+            conn: The live DuckDB connection.
+            user_id: The user id to look up.
+
+        Returns:
+            ``(id, email, password_hash, status, edition, created_at)`` or
+            ``None``.
+        """
+        return conn.execute(
+            "SELECT id, email, password_hash, status, edition, created_at FROM users WHERE id = ?",
+            [user_id],
+        ).fetchone()
+
+    async def activate_user(self, conn: duckdb.DuckDBPyConnection, user_id: str) -> None:
+        """Transition a user to the ``active`` status.
+
+        Args:
+            conn: The live DuckDB connection.
+            user_id: The id of the user to activate.
+        """
+        conn.execute(
+            "UPDATE users SET status = ? WHERE id = ?",
+            [UserStatus.ACTIVE.value, user_id],
+        )

--- a/app/auth/users/user_status.py
+++ b/app/auth/users/user_status.py
@@ -1,0 +1,17 @@
+"""The lifecycle status of a user row."""
+
+from enum import StrEnum
+
+
+class UserStatus(StrEnum):
+    """The ``status`` column of the ``users`` table.
+
+    A user is created ``pending`` at sign-up, becomes ``active`` after email
+    verification, and may be ``disabled`` by an operator. Mirrors the DDL
+    ``CHECK`` constraint so the allowed values live in exactly one place in the
+    Python layer.
+    """
+
+    PENDING = "pending"
+    ACTIVE = "active"
+    DISABLED = "disabled"

--- a/app/configurations/database.yaml
+++ b/app/configurations/database.yaml
@@ -64,6 +64,42 @@ database:
           type: VARCHAR
         - name: version_id
           type: VARCHAR
+    - name: users
+      fields:
+        - name: id
+          type: VARCHAR PRIMARY KEY
+        - name: email
+          type: VARCHAR
+        - name: password_hash
+          type: VARCHAR
+        - name: status
+          type: VARCHAR
+        - name: edition
+          type: VARCHAR
+        - name: created_at
+          type: TIMESTAMP
+    - name: sessions
+      fields:
+        - name: id
+          type: VARCHAR PRIMARY KEY
+        - name: user_id
+          type: VARCHAR
+        - name: token_hash
+          type: VARCHAR
+        - name: created_at
+          type: TIMESTAMP
+        - name: expires_at
+          type: TIMESTAMP
+    - name: email_verification_tokens
+      fields:
+        - name: token_hash
+          type: VARCHAR PRIMARY KEY
+        - name: user_id
+          type: VARCHAR
+        - name: expires_at
+          type: TIMESTAMP
+        - name: consumed_at
+          type: TIMESTAMP
 
 duck_db:
   database: test.db

--- a/app/database/duckdb/ddl.sql
+++ b/app/database/duckdb/ddl.sql
@@ -47,3 +47,30 @@ CREATE TABLE IF NOT EXISTS release_components (
     version_id VARCHAR NOT NULL,
     PRIMARY KEY (release_id, component_id)
 );
+
+-- Auth (P4): password/session users and their opaque, hashed tokens.
+-- Passwords are stored as argon2id hashes; session and verification tokens are
+-- stored only as their SHA-256 hashes (the raw token is never persisted).
+CREATE TABLE IF NOT EXISTS users (
+    id VARCHAR PRIMARY KEY,
+    email VARCHAR NOT NULL UNIQUE,
+    password_hash VARCHAR NOT NULL,
+    status VARCHAR NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'active', 'disabled')),
+    edition VARCHAR,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id VARCHAR PRIMARY KEY,
+    user_id VARCHAR NOT NULL REFERENCES users(id),
+    token_hash VARCHAR NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS email_verification_tokens (
+    token_hash VARCHAR PRIMARY KEY,
+    user_id VARCHAR NOT NULL REFERENCES users(id),
+    expires_at TIMESTAMP NOT NULL,
+    consumed_at TIMESTAMP
+);

--- a/app/errors/domain_not_allowed_error.py
+++ b/app/errors/domain_not_allowed_error.py
@@ -1,0 +1,18 @@
+"""Typed error for a sign-up email whose domain is not allow-listed (HTTP 403)."""
+
+from fastapi import status
+
+from app.errors.domain_error import DomainError
+from app.errors.error_code import ErrorCode
+
+
+class DomainNotAllowedError(DomainError):
+    """Raised when a sign-up email's domain is not on the configured allow-list.
+
+    Serializes to HTTP 403 with envelope code ``domain_not_allowed`` (see
+    ``docs/design/API_CONTRACT.md`` §2). Provided here as part of the shared
+    auth spine so the password sign-up lane (R1) can raise it directly.
+    """
+
+    http_status: int = status.HTTP_403_FORBIDDEN
+    code: ErrorCode = ErrorCode.DOMAIN_NOT_ALLOWED

--- a/app/errors/error_code.py
+++ b/app/errors/error_code.py
@@ -13,5 +13,8 @@ class ErrorCode(StrEnum):
     NOT_FOUND = "not_found"
     CONFLICT = "conflict"
     VALIDATION_ERROR = "validation_error"
+    UNAUTHORIZED = "unauthorized"
+    FORBIDDEN = "forbidden"
+    DOMAIN_NOT_ALLOWED = "domain_not_allowed"
     HTTP_ERROR = "http_error"
     INTERNAL_ERROR = "internal_error"

--- a/app/errors/forbidden_error.py
+++ b/app/errors/forbidden_error.py
@@ -1,0 +1,19 @@
+"""Typed error for an authenticated-but-not-permitted request (HTTP 403)."""
+
+from fastapi import status
+
+from app.errors.domain_error import DomainError
+from app.errors.error_code import ErrorCode
+
+
+class ForbiddenError(DomainError):
+    """Raised when a caller is authenticated but not permitted to act.
+
+    Serializes to HTTP 403 with envelope code ``forbidden`` (see
+    ``docs/design/API_CONTRACT.md`` §3). For the specific "email domain is not
+    on the allow-list" case, raise :class:`DomainNotAllowedError` instead so the
+    client receives the ``domain_not_allowed`` code.
+    """
+
+    http_status: int = status.HTTP_403_FORBIDDEN
+    code: ErrorCode = ErrorCode.FORBIDDEN

--- a/app/errors/handlers.py
+++ b/app/errors/handlers.py
@@ -20,6 +20,8 @@ from app.errors.error_envelope import ErrorEnvelope
 # ``http_error`` fallback. Kept as a mapping (config-style) rather than inline
 # magic numbers in branches.
 _HTTP_STATUS_TO_CODE: dict[int, ErrorCode] = {
+    status.HTTP_401_UNAUTHORIZED: ErrorCode.UNAUTHORIZED,
+    status.HTTP_403_FORBIDDEN: ErrorCode.FORBIDDEN,
     status.HTTP_404_NOT_FOUND: ErrorCode.NOT_FOUND,
     status.HTTP_409_CONFLICT: ErrorCode.CONFLICT,
 }

--- a/app/errors/unauthorized_error.py
+++ b/app/errors/unauthorized_error.py
@@ -1,0 +1,18 @@
+"""Typed error for a missing or invalid credential (HTTP 401)."""
+
+from fastapi import status
+
+from app.errors.domain_error import DomainError
+from app.errors.error_code import ErrorCode
+
+
+class UnauthorizedError(DomainError):
+    """Raised when a request carries no valid credential.
+
+    Serializes to HTTP 401 with envelope code ``unauthorized`` (see
+    ``docs/design/API_CONTRACT.md`` §3). Raised by the auth resolver when at
+    least one provider is enabled but none authenticate the request.
+    """
+
+    http_status: int = status.HTTP_401_UNAUTHORIZED
+    code: ErrorCode = ErrorCode.UNAUTHORIZED

--- a/app/mail/__init__.py
+++ b/app/mail/__init__.py
@@ -1,0 +1,7 @@
+"""Mail abstraction for the auth lanes.
+
+A :class:`~app.mail.mailer.Mailer` sends transactional email (email-verification
+tokens). The v1 pipeline ships :class:`~app.mail.capture_mailer.CaptureMailer`, an
+in-memory sink that makes the verification flow deterministic and testable with
+no SMTP daemon. A single instance lives on ``app.state.mailer``.
+"""

--- a/app/mail/capture_mailer.py
+++ b/app/mail/capture_mailer.py
@@ -1,0 +1,55 @@
+"""An in-memory :class:`~app.mail.mailer.Mailer` that records sent messages."""
+
+from app.mail.captured_email import CapturedEmail
+from app.mail.mailer import Mailer
+
+
+class CaptureMailer(Mailer):
+    """A deterministic mail sink that stores sent messages in memory.
+
+    This is the v1 email transport: instead of talking to an SMTP daemon it
+    appends every send to an in-memory list, so the sign-up/verify flow can be
+    driven end to end (retrieve the verification token straight from the last
+    captured message). A single instance is app-scoped on ``app.state.mailer``.
+    """
+
+    def __init__(self) -> None:
+        """Initialise an empty capture buffer."""
+        self._messages: list[CapturedEmail] = []
+
+    def send(self, to: str, subject: str, body: str) -> None:
+        """Record an email in the in-memory buffer.
+
+        Args:
+            to: The recipient address.
+            subject: The email subject line.
+            body: The email body.
+        """
+        self._messages.append(CapturedEmail(to=to, subject=subject, body=body))
+
+    def messages(self) -> tuple[CapturedEmail, ...]:
+        """Return every captured message in send order."""
+        return tuple(self._messages)
+
+    def last_message(self) -> CapturedEmail | None:
+        """Return the most recently captured message, or ``None`` when empty."""
+        return self._messages[-1] if self._messages else None
+
+    def last_for(self, recipient: str) -> CapturedEmail | None:
+        """Return the most recent message sent to a recipient.
+
+        Args:
+            recipient: The recipient address to search for.
+
+        Returns:
+            The latest :class:`CapturedEmail` addressed to ``recipient``, or
+            ``None`` when none was sent.
+        """
+        for message in reversed(self._messages):
+            if message.to == recipient:
+                return message
+        return None
+
+    def clear(self) -> None:
+        """Discard all captured messages."""
+        self._messages.clear()

--- a/app/mail/captured_email.py
+++ b/app/mail/captured_email.py
@@ -1,0 +1,16 @@
+"""A single email captured by the in-memory mailer."""
+
+from pydantic import BaseModel
+
+
+class CapturedEmail(BaseModel):
+    """An email recorded by :class:`~app.mail.capture_mailer.CaptureMailer`.
+
+    Intentionally carries no timestamp: the capture sink is a deterministic test
+    double, and minting a wall-clock time here would introduce non-determinism
+    (and there is no request/DB clock to borrow at send time).
+    """
+
+    to: str
+    subject: str
+    body: str

--- a/app/mail/mailer.py
+++ b/app/mail/mailer.py
@@ -1,0 +1,23 @@
+"""The mail-sending abstraction the auth lanes depend on."""
+
+from abc import ABC, abstractmethod
+
+
+class Mailer(ABC):
+    """Sends a transactional email.
+
+    Kept deliberately minimal so backends (in-memory capture now, SMTP/provider
+    later) are interchangeable behind the same contract. Resource and auth lanes
+    depend on this abstraction, not a concrete transport.
+    """
+
+    @abstractmethod
+    def send(self, to: str, subject: str, body: str) -> None:
+        """Send an email.
+
+        Args:
+            to: The recipient address.
+            subject: The email subject line.
+            body: The email body.
+        """
+        raise NotImplementedError

--- a/app/mail/mailer_dependency.py
+++ b/app/mail/mailer_dependency.py
@@ -1,0 +1,32 @@
+"""FastAPI dependency exposing the application-managed :class:`Mailer`.
+
+Mirrors :func:`app.connections.db_dependency.get_db_connection`: the concrete
+mailer is placed on ``app.state.mailer`` by the application lifespan. When the
+app was started without a lifespan (for example a bare ``TestClient``), a
+:class:`~app.mail.capture_mailer.CaptureMailer` is created lazily and stored on
+``app.state`` so it persists across requests and remains inspectable — this
+keeps the sign-up/verify flow drivable without an SMTP daemon.
+"""
+
+from fastapi import Request
+
+from app.mail.capture_mailer import CaptureMailer
+from app.mail.mailer import Mailer
+
+
+def get_mailer(request: Request) -> Mailer:
+    """Return the application-managed mailer.
+
+    Args:
+        request: The incoming request, used to reach ``app.state``.
+
+    Returns:
+        The live :class:`Mailer` managed by the application lifespan, or a
+        lazily-created capture mailer when none was installed.
+    """
+    state = request.app.state
+    mailer = state.mailer if hasattr(state, "mailer") else None
+    if mailer is None:
+        mailer = CaptureMailer()
+        state.mailer = mailer
+    return mailer

--- a/app/main.py
+++ b/app/main.py
@@ -6,12 +6,15 @@ import duckdb
 import uvicorn
 from fastapi import FastAPI, Request, Response
 
+from app.auth.auth_resolver_factory import AuthResolverFactory
+from app.auth.auth_settings import AuthSettings
 from app.connections.connection_factory import ConnectionFactory
 from app.database.database_manager import DatabaseManager
 from app.database.migration.flat_to_relational_migration import FlatToRelationalMigration
 from app.errors.handlers import register_error_handlers
 from app.events.event_bus import EventBus
-from app.routers import components, events, products, releases, timeline, versions
+from app.mail.capture_mailer import CaptureMailer
+from app.routers import auth, components, events, meta, products, releases, timeline, versions
 
 logger = logging.getLogger("lavs-api")
 
@@ -27,6 +30,17 @@ async def lifespan(application: FastAPI) -> AsyncIterator[None]:
     handlers and dependencies can reuse it, and is closed automatically at
     shutdown. A single in-process :class:`EventBus` is created and exposed on
     ``application.state.event_bus`` for the SSE and cut-release lanes to share.
+
+    The auth spine is also assembled here: :class:`AuthSettings` is read from the
+    environment, an :class:`~app.auth.auth_registry.AuthRegistry` is populated
+    with the enabled providers (the API-key provider today), and an
+    :class:`~app.auth.auth_resolver.AuthResolver` over it is exposed on
+    ``application.state.auth_resolver``. The registry itself is exposed on
+    ``application.state.auth_registry`` so a later lane (R2's
+    ``PasswordSessionProvider``) can register onto it — the resolver reads the
+    registry live, so a provider added after startup still takes effect. A
+    :class:`~app.mail.capture_mailer.CaptureMailer` is exposed on
+    ``application.state.mailer`` as the deterministic email sink.
     """
     with ConnectionFactory().connect(key="duckdb") as raw_connection:
         if not isinstance(raw_connection, duckdb.DuckDBPyConnection):
@@ -34,6 +48,16 @@ async def lifespan(application: FastAPI) -> AsyncIterator[None]:
         connection = raw_connection
         application.state.db_connection = connection
         application.state.event_bus = EventBus()
+
+        auth_settings = AuthSettings()
+        auth_registry = AuthResolverFactory.build_registry(auth_settings)
+        application.state.auth_settings = auth_settings
+        application.state.auth_registry = auth_registry
+        application.state.auth_resolver = AuthResolverFactory.build_resolver(
+            auth_settings, registry=auth_registry
+        )
+        application.state.mailer = CaptureMailer()
+
         logger.info("Managed DuckDB connection opened for application lifespan.")
         DatabaseManager.create_tables()
         FlatToRelationalMigration().run(connection)
@@ -43,6 +67,10 @@ async def lifespan(application: FastAPI) -> AsyncIterator[None]:
         finally:
             application.state.db_connection = None
             application.state.event_bus = None
+            application.state.auth_settings = None
+            application.state.auth_registry = None
+            application.state.auth_resolver = None
+            application.state.mailer = None
             logger.info("Managed DuckDB connection closed for application lifespan.")
 
 
@@ -94,6 +122,8 @@ def ready(response: Response, request: Request) -> dict[str, str]:
     return {"status": "ready"}
 
 
+app.include_router(meta.router)
+app.include_router(auth.router)
 app.include_router(products.router)
 app.include_router(components.router)
 app.include_router(versions.router)

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI, Request, Response
 
 from app.auth.auth_resolver_factory import AuthResolverFactory
 from app.auth.auth_settings import AuthSettings
+from app.auth.providers.password_session_provider import PasswordSessionProvider
 from app.connections.connection_factory import ConnectionFactory
 from app.database.database_manager import DatabaseManager
 from app.database.migration.flat_to_relational_migration import FlatToRelationalMigration
@@ -51,6 +52,8 @@ async def lifespan(application: FastAPI) -> AsyncIterator[None]:
 
         auth_settings = AuthSettings()
         auth_registry = AuthResolverFactory.build_registry(auth_settings)
+        if auth_settings.password_enabled():
+            auth_registry.register(PasswordSessionProvider(edition=auth_settings.edition()))
         application.state.auth_settings = auth_settings
         application.state.auth_registry = auth_registry
         application.state.auth_resolver = AuthResolverFactory.build_resolver(

--- a/app/models/requests/login_model.py
+++ b/app/models/requests/login_model.py
@@ -1,0 +1,25 @@
+"""Request body for ``POST /auth/login``."""
+
+from typing import Annotated
+
+from annotated_types import MinLen
+
+from app.models.requests.request_model import RequestModel
+
+
+class LoginModel(RequestModel):
+    """JSON body carrying a login credential.
+
+    Both fields are required and non-empty; a request that omits either is a
+    422 (malformed) rather than a 401 (bad credentials). See
+    ``docs/design/API_CONTRACT.md`` §2.
+    """
+
+    email: Annotated[str, MinLen(1)]
+    password: Annotated[str, MinLen(1)]
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{"email": "engineer@example.com", "password": "correct horse battery"}]
+        }
+    }

--- a/app/models/requests/login_model.py
+++ b/app/models/requests/login_model.py
@@ -3,6 +3,7 @@
 from typing import Annotated
 
 from annotated_types import MinLen
+from pydantic import field_validator
 
 from app.models.requests.request_model import RequestModel
 
@@ -11,12 +12,27 @@ class LoginModel(RequestModel):
     """JSON body carrying a login credential.
 
     Both fields are required and non-empty; a request that omits either is a
-    422 (malformed) rather than a 401 (bad credentials). See
+    422 (malformed) rather than a 401 (bad credentials). The email is normalised
+    (trimmed + lower-cased) identically to sign-up so a case/whitespace variant
+    of a registered address still resolves the same account. See
     ``docs/design/API_CONTRACT.md`` §2.
     """
 
     email: Annotated[str, MinLen(1)]
     password: Annotated[str, MinLen(1)]
+
+    @field_validator("email")
+    @classmethod
+    def _normalize_email(cls, value: str) -> str:
+        """Trim and lower-case the email to match the stored form.
+
+        Args:
+            value: The raw email from the request body.
+
+        Returns:
+            The normalised (lower-cased, trimmed) email.
+        """
+        return value.strip().lower()
 
     model_config = {
         "json_schema_extra": {

--- a/app/models/requests/signup_model.py
+++ b/app/models/requests/signup_model.py
@@ -1,0 +1,48 @@
+"""Request body for ``POST /auth/signup``."""
+
+import re
+from typing import Annotated
+
+from annotated_types import MinLen
+from pydantic import field_validator
+
+from app.auth.signup.signup_policy import SignupPolicy
+from app.models.requests.request_model import RequestModel
+
+
+class SignupModel(RequestModel):
+    """JSON body for ``POST /auth/signup``.
+
+    ``EmailStr`` is intentionally not used: pydantic's email type requires the
+    ``email-validator`` package, which is not a project dependency. Instead the
+    email is normalised (trimmed + lower-cased) and shape-checked against
+    :attr:`SignupPolicy.EMAIL_PATTERN`. See ``docs/design/API_CONTRACT.md`` §2.
+    """
+
+    email: str
+    password: Annotated[str, MinLen(SignupPolicy.MIN_PASSWORD_LENGTH)]
+
+    @field_validator("email")
+    @classmethod
+    def _normalize_email(cls, value: str) -> str:
+        """Trim, lower-case, and shape-check the email address.
+
+        Args:
+            value: The raw email from the request body.
+
+        Returns:
+            The normalised (lower-cased, trimmed) email.
+
+        Raises:
+            ValueError: When the value is not a plausible email address.
+        """
+        normalized = value.strip().lower()
+        if re.fullmatch(SignupPolicy.EMAIL_PATTERN, normalized) is None:
+            raise ValueError("A valid email address is required.")
+        return normalized
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{"email": "engineer@example.com", "password": "correct horse battery"}]
+        }
+    }

--- a/app/models/requests/verify_model.py
+++ b/app/models/requests/verify_model.py
@@ -1,0 +1,20 @@
+"""Request body for ``POST /auth/verify``."""
+
+from typing import Annotated
+
+from annotated_types import MinLen
+
+from app.models.requests.request_model import RequestModel
+
+
+class VerifyModel(RequestModel):
+    """JSON body for ``POST /auth/verify``.
+
+    Carries the raw verification token delivered by email. The token is hashed
+    before any lookup; the raw value is never persisted. See
+    ``docs/design/API_CONTRACT.md`` §2.
+    """
+
+    token: Annotated[str, MinLen(1)]
+
+    model_config = {"json_schema_extra": {"examples": [{"token": "Xy8f…opaque-url-safe-token"}]}}

--- a/app/models/responses/meta_response_model.py
+++ b/app/models/responses/meta_response_model.py
@@ -1,0 +1,21 @@
+"""Response body for the public ``GET /meta`` capability endpoint."""
+
+from app.models.responses.response_model import ResponseModel
+
+
+class MetaResponseModel(ResponseModel):
+    """Deployment capabilities the UI reads to render the right login.
+
+    See ``docs/design/API_CONTRACT.md`` §8: the UI branches on ``edition`` and
+    the enabled ``auth_modes`` (password form vs configured-key vs Stytch
+    widget). Public — it must be reachable before a principal exists.
+    """
+
+    edition: str
+    auth_modes: list[str]
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{"edition": "oss", "auth_modes": ["password", "apikey"]}]
+        }
+    }

--- a/app/models/responses/signup_accepted_model.py
+++ b/app/models/responses/signup_accepted_model.py
@@ -1,0 +1,17 @@
+"""Response body acknowledging an accepted sign-up (HTTP 202)."""
+
+from app.auth.signup.signup_status import SignupStatus
+from app.models.responses.response_model import ResponseModel
+
+
+class SignupAcceptedModel(ResponseModel):
+    """The 202 acknowledgement for ``POST /auth/signup``.
+
+    Deliberately reveals nothing about whether the address pre-existed beyond
+    the 409 the contract mandates: a successful sign-up always returns the same
+    ``pending_verification`` status. See ``docs/design/API_CONTRACT.md`` §2.
+    """
+
+    status: SignupStatus = SignupStatus.PENDING_VERIFICATION
+
+    model_config = {"json_schema_extra": {"examples": [{"status": "pending_verification"}]}}

--- a/app/models/responses/user_response_model.py
+++ b/app/models/responses/user_response_model.py
@@ -1,0 +1,29 @@
+"""Response body describing a user (never carries the password hash)."""
+
+from app.models.responses.response_model import ResponseModel
+
+
+class UserResponseModel(ResponseModel):
+    """The safe ``User`` projection returned by the auth endpoints.
+
+    Deliberately omits ``password_hash`` so a user's credential material can
+    never leak through a response. See ``docs/design/API_CONTRACT.md`` §2.
+    """
+
+    id: str
+    email: str
+    status: str
+    edition: str | None = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "id": "01KW8WHA6STWW5N1VYRSHDTK1N",
+                    "email": "engineer@example.com",
+                    "status": "active",
+                    "edition": "oss",
+                }
+            ]
+        }
+    }

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -9,6 +9,94 @@ dependency: the auth routes establish a principal, so they must be reachable
 without one already present. (``/auth/me`` enforces authentication itself.)
 """
 
-from fastapi import APIRouter
+from typing import Annotated
+
+import duckdb
+from fastapi import APIRouter, Depends, Request, status
+
+from app.auth.auth_settings import AuthSettings
+from app.auth.signup.signup_service import SignupService
+from app.auth.signup.verification_service import VerificationService
+from app.connections.db_dependency import get_db_connection
+from app.mail.mailer import Mailer
+from app.mail.mailer_dependency import get_mailer
+from app.models.requests.signup_model import SignupModel
+from app.models.requests.verify_model import VerifyModel
+from app.models.responses.signup_accepted_model import SignupAcceptedModel
+from app.models.responses.user_response_model import UserResponseModel
 
 router = APIRouter(tags=["auth"], prefix="/auth")
+
+DbConnection = Annotated[duckdb.DuckDBPyConnection, Depends(get_db_connection)]
+MailerDep = Annotated[Mailer, Depends(get_mailer)]
+
+
+def _auth_settings(request: Request) -> AuthSettings:
+    """Return the application-managed :class:`AuthSettings`.
+
+    Prefers the settings installed on ``app.state`` by the lifespan; falls back
+    to an environment-built instance when the app was started without one (for
+    example a bare ``TestClient``), mirroring :func:`require_principal`.
+
+    Args:
+        request: The incoming request.
+
+    Returns:
+        The auth settings to apply to this request.
+    """
+    state = request.app.state
+    settings = state.auth_settings if hasattr(state, "auth_settings") else None
+    return settings if settings is not None else AuthSettings()
+
+
+@router.post(
+    "/signup",
+    response_model=SignupAcceptedModel,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def signup(
+    body: SignupModel,
+    conn: DbConnection,
+    mailer: MailerDep,
+    request: Request,
+) -> SignupAcceptedModel:
+    """Register a pending user and email them a verification token.
+
+    Args:
+        body: The sign-up request body (``email`` + ``password``).
+        conn: The application-managed DuckDB connection.
+        mailer: The application-managed mailer delivering the raw token.
+        request: The incoming request, used to reach the auth settings.
+
+    Returns:
+        A 202 acknowledgement with ``pending_verification`` status.
+
+    Raises:
+        DomainNotAllowedError: When the email's domain is not allow-listed (403).
+        ConflictError: When the email is already registered (409).
+    """
+    await SignupService().register(
+        conn=conn, mailer=mailer, model=body, settings=_auth_settings(request)
+    )
+    return SignupAcceptedModel()
+
+
+@router.post("/verify", response_model=UserResponseModel)
+async def verify(
+    body: VerifyModel,
+    conn: DbConnection,
+) -> UserResponseModel:
+    """Verify an email token, activating the corresponding user.
+
+    Args:
+        body: The verify request body carrying the raw token.
+        conn: The application-managed DuckDB connection.
+
+    Returns:
+        The activated user as a safe :class:`UserResponseModel`.
+
+    Raises:
+        NotFoundError: When the token is unknown, expired, or already used (a
+            single generic failure — no enumeration).
+    """
+    return await VerificationService().verify(conn=conn, model=body)

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,0 +1,14 @@
+"""Router shell for the ``/auth`` resource.
+
+A deliberate shell carrying only the prefix and tag — the password-auth lanes
+add the routes (R1: ``/auth/signup`` + ``/auth/verify``; R2: ``/auth/login`` +
+``/auth/logout`` + ``/auth/me``). See ``docs/design/API_CONTRACT.md`` §2.
+
+Critically, this router does **not** declare the ``require_principal``
+dependency: the auth routes establish a principal, so they must be reachable
+without one already present. (``/auth/me`` enforces authentication itself.)
+"""
+
+from fastapi import APIRouter
+
+router = APIRouter(tags=["auth"], prefix="/auth")

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,14 +1,190 @@
 """Router shell for the ``/auth`` resource.
 
-A deliberate shell carrying only the prefix and tag — the password-auth lanes
-add the routes (R1: ``/auth/signup`` + ``/auth/verify``; R2: ``/auth/login`` +
+A deliberate shell carrying the prefix and tag; the password-auth lanes add the
+routes (R1: ``/auth/signup`` + ``/auth/verify``; R2: ``/auth/login`` +
 ``/auth/logout`` + ``/auth/me``). See ``docs/design/API_CONTRACT.md`` §2.
 
-Critically, this router does **not** declare the ``require_principal``
+Critically, this router does **not** declare a router-level ``require_principal``
 dependency: the auth routes establish a principal, so they must be reachable
-without one already present. (``/auth/me`` enforces authentication itself.)
+without one already present. ``/auth/me`` enforces authentication itself via a
+per-route dependency.
+
+Security posture of the login lane:
+
+* Failures are **generic** — a wrong password, an unknown email, and an
+  unverified/disabled account all return the same ``401 invalid credentials``,
+  so a response never reveals whether an account exists or its status (no user
+  enumeration).
+* The password check runs even when no user matched (against a throwaway hash),
+  so the request cannot be enumerated by timing either.
+* The session token is high-entropy, stored only as its hash with a TTL, and
+  the cookie is ``HttpOnly``/``Secure``/``SameSite=Lax``.
 """
 
-from fastapi import APIRouter
+import secrets
+from typing import Annotated
+
+import duckdb
+from fastapi import APIRouter, Depends, Request, Response, status
+
+from app.auth.auth_settings import AuthSettings
+from app.auth.password_hasher import PasswordHasher
+from app.auth.require_principal import PrincipalDep
+from app.auth.session.session_cookie import SessionCookie
+from app.auth.session.session_service import SessionService
+from app.auth.users.user_repository import UserRepository
+from app.auth.users.user_status import UserStatus
+from app.connections.db_dependency import get_db_connection
+from app.errors.unauthorized_error import UnauthorizedError
+from app.models.requests.login_model import LoginModel
+from app.models.responses.user_response_model import UserResponseModel
 
 router = APIRouter(tags=["auth"], prefix="/auth")
+
+DbConnection = Annotated[duckdb.DuckDBPyConnection, Depends(get_db_connection)]
+
+_GENERIC_LOGIN_FAILURE = "invalid credentials"
+
+# A throwaway argon2 hash used to equalise timing when no user matched, so the
+# presence of an account cannot be inferred from how long a login takes. Minted
+# once at import over a random secret; it can never match a real password.
+_TIMING_EQUALISER_HASH = PasswordHasher().hash_password(secrets.token_urlsafe(32))
+
+
+def _auth_settings_for(request: Request) -> AuthSettings:
+    """Return the deployment auth settings for the request.
+
+    Prefers the application-managed settings on ``app.state`` and falls back to
+    an environment-read instance when the app was started without a lifespan,
+    mirroring :mod:`app.auth.require_principal`.
+
+    Args:
+        request: The incoming request.
+
+    Returns:
+        The auth settings to read the session TTL and edition from.
+    """
+    state = request.app.state
+    if hasattr(state, "auth_settings") and state.auth_settings is not None:
+        settings: AuthSettings = state.auth_settings
+        return settings
+    return AuthSettings()
+
+
+@router.post("/login", response_model=UserResponseModel)
+async def login(
+    body: LoginModel,
+    request: Request,
+    response: Response,
+    conn: DbConnection,
+) -> UserResponseModel:
+    """Authenticate a user and open a session.
+
+    Verifies the password against the stored argon2 hash and requires an
+    ``active`` account. On success a fresh session is created — its token stored
+    only as a hash with a TTL — and the raw token is set as the ``lavs_session``
+    cookie. On **any** failure a single generic 401 is returned.
+
+    Args:
+        body: The login request body (``email`` and ``password``).
+        request: The incoming request, used to read the deployment settings.
+        response: The outgoing response, used to set the session cookie.
+        conn: The application-managed DuckDB connection.
+
+    Returns:
+        The authenticated user as a safe :class:`UserResponseModel`.
+
+    Raises:
+        UnauthorizedError: On unknown email, wrong password, or a non-active
+            account — always with the same generic message.
+    """
+    user_row = await UserRepository().get_user_by_email(conn, body.email)
+    stored_hash = str(user_row[2]) if user_row is not None else _TIMING_EQUALISER_HASH
+
+    password_ok = PasswordHasher().verify_password(stored_hash, body.password)
+
+    if user_row is None or not password_ok or str(user_row[3]) != UserStatus.ACTIVE.value:
+        raise UnauthorizedError(message=_GENERIC_LOGIN_FAILURE)
+
+    settings = _auth_settings_for(request)
+    ttl_seconds = settings.session_ttl_seconds()
+    token = SessionService().create_session(conn, user_id=str(user_row[0]), ttl_seconds=ttl_seconds)
+
+    response.set_cookie(
+        key=SessionCookie.NAME,
+        value=token,
+        max_age=ttl_seconds,
+        httponly=SessionCookie.HTTP_ONLY,
+        secure=SessionCookie.SECURE,
+        samesite=SessionCookie.SAME_SITE,
+        path=SessionCookie.PATH,
+    )
+
+    return UserResponseModel(
+        id=str(user_row[0]),
+        email=str(user_row[1]),
+        status=str(user_row[3]),
+        edition=None if user_row[4] is None else str(user_row[4]),
+    )
+
+
+@router.get("/me", response_model=UserResponseModel)
+async def me(conn: DbConnection, principal: PrincipalDep) -> UserResponseModel:
+    """Return the currently authenticated caller.
+
+    Resolves the request's principal (a user via the session cookie, or any
+    other configured provider) and returns its user projection. An
+    unauthenticated request is rejected with 401 by ``require_principal`` before
+    this handler runs.
+
+    Args:
+        conn: The application-managed DuckDB connection.
+        principal: The resolved principal (injected by ``require_principal``).
+
+    Returns:
+        The caller as a :class:`UserResponseModel`.
+    """
+    user_row = await UserRepository().get_user_by_id(conn, principal.id)
+    if user_row is not None:
+        return UserResponseModel(
+            id=str(user_row[0]),
+            email=str(user_row[1]),
+            status=str(user_row[3]),
+            edition=None if user_row[4] is None else str(user_row[4]),
+        )
+
+    return UserResponseModel(
+        id=principal.id,
+        email=principal.email if principal.email is not None else principal.id,
+        status=UserStatus.ACTIVE.value,
+        edition=principal.edition,
+    )
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+async def logout(request: Request, conn: DbConnection) -> Response:
+    """Revoke the current session and clear the session cookie.
+
+    Idempotent: a request without a session cookie still succeeds. The matching
+    session row (if any) is deleted and the cookie is cleared.
+
+    Args:
+        request: The incoming request, used to read the session cookie.
+        conn: The application-managed DuckDB connection.
+
+    Returns:
+        An empty ``204 No Content`` response that clears the cookie.
+    """
+    token = request.cookies.get(SessionCookie.NAME)
+    if token is not None and token != "":
+        SessionService().delete_session(conn, token)
+
+    response = Response(status_code=status.HTTP_204_NO_CONTENT)
+    response.delete_cookie(
+        key=SessionCookie.NAME,
+        path=SessionCookie.PATH,
+        httponly=SessionCookie.HTTP_ONLY,
+        secure=SessionCookie.SECURE,
+        samesite=SessionCookie.SAME_SITE,
+    )
+    return response

--- a/app/routers/components.py
+++ b/app/routers/components.py
@@ -1,6 +1,6 @@
 """Router for the ``/components`` resource.
 
-The shell fixes the prefix, tag, and the mandatory API-key dependency so auth is
+The shell fixes the prefix, tag, and the mandatory authenticated-principal dependency so auth is
 enforced uniformly; the routes below add component creation and the immutable
 per-component version history. Every database value is bound through
 parameterized SQL in the query layer.
@@ -11,6 +11,7 @@ from typing import Annotated
 import duckdb
 from fastapi import APIRouter, Depends, status
 
+from app.auth.require_principal import require_principal
 from app.connections.db_dependency import get_db_connection
 from app.models.requests.create_component_model import CreateComponentModel
 from app.models.responses.component_response_model import ComponentResponseModel
@@ -20,12 +21,11 @@ from app.queries.components.list_component_versions_query import ListComponentVe
 from app.queries.components.list_component_versions_request import (
     ListComponentVersionsRequest,
 )
-from app.security.api_key import get_api_key
 
 router = APIRouter(
     tags=["components"],
     prefix="/components",
-    dependencies=[Depends(get_api_key)],
+    dependencies=[Depends(require_principal)],
 )
 
 DbConnection = Annotated[duckdb.DuckDBPyConnection, Depends(get_db_connection)]

--- a/app/routers/events.py
+++ b/app/routers/events.py
@@ -2,7 +2,7 @@
 
 Carries no prefix; the SSE lane adds ``GET /products/{id}/events`` (a
 ``text/event-stream`` response, see ``docs/design/API_CONTRACT.md`` §6) on the
-shared ``router`` below, which fixes the tag and the mandatory API-key
+shared ``router`` below, which fixes the tag and the mandatory authenticated-principal
 dependency so auth is enforced uniformly.
 """
 
@@ -11,14 +11,14 @@ from typing import Annotated
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 
+from app.auth.require_principal import require_principal
 from app.events.event_bus import EventBus
 from app.events.event_bus_dependency import get_event_bus
-from app.security.api_key import get_api_key
 from app.sse.sse_event_stream import sse_event_stream
 
 router = APIRouter(
     tags=["events"],
-    dependencies=[Depends(get_api_key)],
+    dependencies=[Depends(require_principal)],
 )
 
 Bus = Annotated[EventBus, Depends(get_event_bus)]

--- a/app/routers/meta.py
+++ b/app/routers/meta.py
@@ -1,0 +1,59 @@
+"""The public ``GET /meta`` capability endpoint.
+
+Reports the deployment ``edition`` and its enabled ``auth_modes`` so the UI can
+render the correct login. Intentionally requires **no** principal — the client
+reads it before authenticating (see ``docs/design/API_CONTRACT.md`` §8).
+"""
+
+from fastapi import APIRouter, Request
+
+from app.auth.auth_mode import AuthMode
+from app.auth.auth_settings import AuthSettings
+from app.models.responses.meta_response_model import MetaResponseModel
+from app.security.api_key import is_authentication_enabled
+
+router = APIRouter(tags=["meta"])
+
+
+def _settings_for(request: Request) -> AuthSettings:
+    """Return the app-managed auth settings, or an env-built fallback."""
+    state = request.app.state
+    settings = state.auth_settings if hasattr(state, "auth_settings") else None
+    if settings is None:
+        return AuthSettings()
+    return settings
+
+
+def _enabled_auth_modes(settings: AuthSettings) -> list[str]:
+    """Compute the auth modes actually enabled for this deployment.
+
+    A configured API key enables ``apikey`` even when it is not explicitly named
+    in ``LAVS_AUTH_MODES`` (mirroring the provider-enablement rule).
+
+    Args:
+        settings: The deployment auth settings.
+
+    Returns:
+        The enabled mode values, sorted for a stable response.
+    """
+    modes = set(settings.modes())
+    if is_authentication_enabled():
+        modes.add(AuthMode.APIKEY)
+    return sorted(mode.value for mode in modes)
+
+
+@router.get("/meta", response_model=MetaResponseModel)
+def get_meta(request: Request) -> MetaResponseModel:
+    """Report the deployment edition and enabled auth modes.
+
+    Args:
+        request: The incoming request, used to reach the managed settings.
+
+    Returns:
+        The public capability descriptor.
+    """
+    settings = _settings_for(request)
+    return MetaResponseModel(
+        edition=settings.edition(),
+        auth_modes=_enabled_auth_modes(settings),
+    )

--- a/app/routers/products.py
+++ b/app/routers/products.py
@@ -2,7 +2,7 @@
 
 Implements product listing, creation (with duplicate-name conflict handling),
 single-product retrieval, and listing a product's components. The prefix, tag,
-and mandatory API-key dependency are fixed on the shared ``router`` below; each
+and mandatory authenticated-principal dependency are fixed on the shared ``router`` below; each
 handler delegates persistence to a dedicated :class:`~app.queries.query.Query`
 and reuses the application-managed DuckDB connection.
 """
@@ -12,6 +12,7 @@ from typing import Annotated
 import duckdb
 from fastapi import APIRouter, Depends, status
 
+from app.auth.require_principal import require_principal
 from app.connections.db_dependency import get_db_connection
 from app.models.requests.create_product_model import CreateProductModel
 from app.models.requests.request_model import RequestModel
@@ -24,12 +25,11 @@ from app.queries.products.list_components_by_product_query import (
 )
 from app.queries.products.list_products_query import ListProductsQuery
 from app.queries.products.product_id_request import ProductIdRequest
-from app.security.api_key import get_api_key
 
 router = APIRouter(
     tags=["products"],
     prefix="/products",
-    dependencies=[Depends(get_api_key)],
+    dependencies=[Depends(require_principal)],
 )
 
 DbConnection = Annotated[duckdb.DuckDBPyConnection, Depends(get_db_connection)]

--- a/app/routers/releases.py
+++ b/app/routers/releases.py
@@ -3,7 +3,7 @@
 Deliberately carries **no prefix**: releases are addressed under two roots —
 ``/products/{id}/releases`` (list + cut) and ``/releases/{id}`` (read one) — so
 each route declares its full path. The shell fixes only the tag and the
-mandatory API-key dependency; the cut/list routes are added by the release-write
+mandatory authenticated-principal dependency; the cut/list routes are added by the release-write
 lane and the read route by the release-read lane.
 """
 
@@ -12,6 +12,7 @@ from typing import Annotated
 import duckdb
 from fastapi import APIRouter, Depends, Header
 
+from app.auth.require_principal import require_principal
 from app.connections.db_dependency import get_db_connection
 from app.events.domain_event import DomainEvent
 from app.events.event_bus import EventBus
@@ -27,11 +28,10 @@ from app.queries.releases_read.list_releases_by_product_query import (
     ListReleasesByProductQuery,
 )
 from app.queries.releases_read.release_id_request import ReleaseIdRequest
-from app.security.api_key import get_api_key
 
 router = APIRouter(
     tags=["releases"],
-    dependencies=[Depends(get_api_key)],
+    dependencies=[Depends(require_principal)],
 )
 
 DbConnection = Annotated[duckdb.DuckDBPyConnection, Depends(get_db_connection)]

--- a/app/routers/timeline.py
+++ b/app/routers/timeline.py
@@ -2,7 +2,7 @@
 
 Mounted under the ``/products`` prefix; the timeline lane adds
 ``GET /{product_id}/timeline``. The shell fixes the prefix, tag, and the
-mandatory API-key dependency so auth is enforced uniformly.
+mandatory authenticated-principal dependency so auth is enforced uniformly.
 """
 
 from typing import Annotated
@@ -10,17 +10,17 @@ from typing import Annotated
 import duckdb
 from fastapi import APIRouter, Depends
 
+from app.auth.require_principal import require_principal
 from app.connections.db_dependency import get_db_connection
 from app.errors.not_found_error import NotFoundError
 from app.models.responses.timeline_response_model import TimelineResponseModel
 from app.queries.timeline.timeline_query import TimelineQuery
 from app.queries.timeline.timeline_request_model import TimelineRequestModel
-from app.security.api_key import get_api_key
 
 router = APIRouter(
     tags=["timeline"],
     prefix="/products",
-    dependencies=[Depends(get_api_key)],
+    dependencies=[Depends(require_principal)],
 )
 
 

--- a/app/routers/versions.py
+++ b/app/routers/versions.py
@@ -1,6 +1,6 @@
 """Routes for the ``/versions`` resource: immutable create and rollback.
 
-The router shell fixes the prefix, tag, and mandatory API-key dependency; this
+The router shell fixes the prefix, tag, and mandatory authenticated-principal dependency; this
 module fills in the two lifecycle endpoints:
 
 * ``POST /versions`` -- append an immutable version, making it the component's
@@ -14,6 +14,7 @@ from typing import Annotated
 import duckdb
 from fastapi import APIRouter, Depends
 
+from app.auth.require_principal import require_principal
 from app.connections.db_dependency import get_db_connection
 from app.events.event_bus import EventBus
 from app.events.event_bus_dependency import get_event_bus
@@ -22,12 +23,11 @@ from app.models.responses.version_response_model import VersionResponseModel
 from app.queries.versions.create_version_query import CreateVersionQuery
 from app.queries.versions.rollback_version_query import RollbackVersionQuery
 from app.queries.versions.rollback_version_request import RollbackVersionRequest
-from app.security.api_key import get_api_key
 
 router = APIRouter(
     tags=["versions"],
     prefix="/versions",
-    dependencies=[Depends(get_api_key)],
+    dependencies=[Depends(require_principal)],
 )
 
 DbConnection = Annotated[duckdb.DuckDBPyConnection, Depends(get_db_connection)]

--- a/docs/planning/ENVIRONMENT.md
+++ b/docs/planning/ENVIRONMENT.md
@@ -62,3 +62,21 @@ or lane-vs-server contention occurs during the fan-out.
 
 ## Readiness signal
 `P2_ENV_READY=GREEN` — all health checks pass at their appropriate points; resource lanes unblocked.
+
+---
+
+# P4 Environment Manifest — 2026-07-11, branch `feat/18-p4-auth-oss`. **Gate: GREEN.**
+
+| # | Service | Status | Verify |
+|---|---|---|---|
+| E1 | Python 3.14 / uv | ✅ 3.14.4 | `import app.main`; `from argon2 import PasswordHasher` |
+| E2 | DuckDB | ✅ | `users`/`sessions`/`email_verification_tokens` present after boot (post-foundation) |
+| E3 | Uvicorn `:8001` | ✅ boots | down during pytest (single-writer protocol) |
+| E4 | pyright | ✅ 0 err | one-shot |
+| E5 | ruff | ✅ clean | — |
+| E6 | pytest | ✅ 257 | baseline |
+| E7 | In-process capture Mailer | ⏸ deferred | foundation code; verified at integration (a verification token is retrievable from the sink) |
+| E8 | Docker | ✅ 29.1.3 | verify-only |
+
+New dep (flagged): **`argon2-cffi` 25.1.0** (argon2id password hashing) → runtime dependency.
+Readiness: `P4_ENV_READY=GREEN`.

--- a/docs/planning/P4_MULTIAGENT_EXECUTION_PLAN.md
+++ b/docs/planning/P4_MULTIAGENT_EXECUTION_PLAN.md
@@ -1,6 +1,14 @@
 # P4 Auth (OSS) — Multiagent Parallel Execution Plan
 
-> **Status:** ⏸ **AWAITING APPROVAL (2026-07-11).** Would branch `feat/18-p4-auth-oss` off `main`
+> **Status:** ✅ **P4 COMPLETE & GREEN (2026-07-11).** OSS auth shipped — pluggable AuthProvider +
+> require_principal (fail-closed when configured, open when not), password+sessions (signup → email/domain
+> verification → login → /auth/me → logout), ApiKeyProvider, /meta. **373 tests**, ruff/pyright clean.
+> **Gate B security review: 11/11 invariants PASS, zero defects** (argon2id, hashed/expiring/single-use
+> tokens, HttpOnly+Secure+SameSite cookies, timing-safe no-enumeration login, 100% parameterized SQL).
+> Live-socket smoke: fail-closed 401 / API-key 200 / /meta correct. One usability fix applied (login email
+> normalization). Signed commits. Next: P3 (Multi-DB) · P5 (Frontend, needs this).
+>
+> **Original plan (awaiting-approval, 2026-07-11).** Would branch `feat/18-p4-auth-oss` off `main`
 > (P2 merged @ `fa010c4`). Commit signing active. Epic #18 · Linear *P4 — Auth (OSS)*.
 > Presented in full per the 9-section governance framework. **Nothing fires until you approve.**
 > (P3 Multi-DB is the parallel alternative — both depend only on P2; redirect if you'd rather do P3.)

--- a/docs/planning/P4_MULTIAGENT_EXECUTION_PLAN.md
+++ b/docs/planning/P4_MULTIAGENT_EXECUTION_PLAN.md
@@ -1,0 +1,143 @@
+# P4 Auth (OSS) — Multiagent Parallel Execution Plan
+
+> **Status:** ⏸ **AWAITING APPROVAL (2026-07-11).** Would branch `feat/18-p4-auth-oss` off `main`
+> (P2 merged @ `fa010c4`). Commit signing active. Epic #18 · Linear *P4 — Auth (OSS)*.
+> Presented in full per the 9-section governance framework. **Nothing fires until you approve.**
+> (P3 Multi-DB is the parallel alternative — both depend only on P2; redirect if you'd rather do P3.)
+
+Delivers real OSS auth per `API_CONTRACT.md` §1–2: a **pluggable `AuthProvider`** selected by deploy
+config, **password + sessions** (signup, email + domain verification, login/logout/me), an **API-key
+provider** wrapping the existing module, and `/meta` reporting `edition` + `auth_modes`.
+
+---
+
+## 1. Conventions loaded
+Same governing set as P0–P2 (re-read): `.claude/conventions/core/general.md` (1-class/file, snake_case,
+typed errors, flag new deps), `.claude/conventions/languages/python.md` (uv/ruff/pyright-strict, `T|None`,
+no constants→enum/config, no `cast`/`setattr`, `__init__.py`, interface-style ABCs, context managers),
+`.prompticorn.yaml` (DuckDB, **raw SQL no ORM**, exceptions, Conventional Commits, coverage L80/B70/F90/S85),
+`ARCHITECTURE.md` (layering, immutable data, lifespan-managed connection, parameterized SQL), `API_CONTRACT.md`
+§1–2 (auth model/flows/endpoints — the authority), `ROADMAP.md` P4 (exit criteria).
+**Gaps flagged:** G1 mutation testing still not wired · G2 `app/`↔`backend/api` drift (unchanged) ·
+**G-P4a — new dependency required** (password hashing — see §8) · **G-P4b — email transport** (in-process
+capture Mailer for the pipeline; SMTP is a config swap; no external mailpit daemon).
+
+## 2. Agent roster → P4 roles
+Orchestration=harness · env-runner=`devops-agent` · **auth abstraction + security=`security-agent`+`backend-agent`**
+(foundation) · signup/verify impl=`code-agent`+`security-agent` (R1) · login/session impl=`code-agent`+`security-agent`
+(R2) · ATDD=`test-agent` (ATDD mode) · TDD=`test-agent` per lane · enforcement=`enforcement-agent` (Gate A) ·
+**security review=`security-agent` (Gate B — heavyweight this phase)** · integration=`review-agent` (Gate C) ·
+debug=`debug-agent`. No-clean-agent gaps (A/B/C) handled as in P0–P2. Security-sensitive phase ⇒ Gate B is
+first-class, not a rubber stamp.
+
+## 3. Environment manifest (Step 4 — hard prerequisite gate)
+`env-setup` (devops persona) stands up + health-checks before any lane; updates `ENVIRONMENT.md`.
+
+| # | Service | Purpose | Health check | Notes |
+|---|---|---|---|---|
+| E1 | Python 3.14 / uv | toolchain | `uv run python -V`; `import app.main` | + new hashing dep (§8) synced |
+| E2 | DuckDB | datastore | `users`+`sessions`+`email_tokens` present after boot | config-driven init |
+| E3 | Uvicorn `:8001 --reload` | live API for E2E | `/health`→200 | **down during pytest** (DuckDB single-writer, per P2 protocol) |
+| E4 | pyright (strict) | types | 0 errors | one-shot per checkpoint |
+| E5 | ruff | lint | clean | — |
+| E6 | pytest + cov | tests | 257 baseline green | — |
+| E7 | **In-process capture Mailer** | catch verification emails deterministically (no SMTP daemon) | a sent verification token is retrievable from the capture sink | replaces external mailpit for the pipeline |
+| E8 | Docker | verify-only | `docker version` | image unchanged |
+
+Any failure ⇒ BLOCKER, escalate. Resource lanes self-verify in their own worktrees.
+
+## 4. Execution map
+```mermaid
+flowchart TB
+    START([✅ You approve]) --> ENV["🔒 env-setup gate (E1–E8) · GREEN"]
+    ENV -- fail --> BLOCK[["⛔ escalate"]]
+    ENV -- green --> FAN{{fan out — ≤4 concurrent}}
+    FAN --> ATDD & R1 & R2
+    subgraph FOUND["✅ built first — FOUNDATION (coherent, coupled spine)"]
+      F["security+backend · AuthProvider ABC + Principal · AuthResolver/require_principal dep ·
+      ApiKeyProvider (wraps api_key.py) · users/sessions/email_tokens schema (config-driven) ·
+      password-hash helper · Mailer abstraction+capture · auth config (LAVS_AUTH_MODES, allowed domains) ·
+      REWIRE all resource routers get_api_key→require_principal · /meta (edition+auth_modes) · auth router shell ·
+      shared user repository"]
+    end
+    START --> F --> ENV
+    subgraph LANES["⫶ parallel lanes (own worktrees + TDD)"]
+      R1["R1 code+security · POST /auth/signup (domain allow-list 403, dup 409, hash pw, pending user,
+      email verification token via Mailer) · POST /auth/verify (activate)"]
+      R2["R2 code+security · POST /auth/login (verify hash, active, set HttpOnly session cookie) ·
+      GET /auth/me · POST /auth/logout · session store · PasswordSessionProvider → resolver"]
+    end
+    ATDD["ATDD · signup→verify→login→me→access resource→logout; domain block; apikey still works; 401 unauth"]
+    R1 & R2 & ATDD --> AGG["🧮 Aggregator (resolve auth-router overlap R1/R2)"]
+    AGG --> GA["Gate A enforcement"] --> GB["Gate B SECURITY (heavyweight)"] --> GC["Gate C integration + live E2E"]
+    GC -- green --> DONE([🎉 signed PR → main])
+    GC -- fail --> DBG["debug-agent · failing lane only, max 2×"] --> AGG
+```
+
+## 5. Subagent specification
+- **env-setup** (devops): E1–E8 + `ENVIRONMENT.md` + readiness GREEN.
+- **Foundation** (security+backend; built + gated before lanes branch): Principal model; `AuthProvider` ABC
+  (`authenticate(request) -> Principal | None`); provider **registry** + `AuthResolver` (tries each enabled
+  provider; passes if any returns a Principal; else 401); `require_principal` FastAPI dependency; **ApiKeyProvider**
+  wrapping `app/security/api_key.py`; **schema** `users(id,email,password_hash,status,created_at)` +
+  `sessions(id,user_id,token_hash,created_at,expires_at)` + `email_verification_tokens(token_hash,user_id,expires_at)`
+  (config-driven init); **password-hash helper** (argon2id); **Mailer** ABC + in-process capture backend;
+  **auth config** (`LAVS_AUTH_MODES`, allowed-domain list, session TTL) via pydantic-settings/YAML;
+  **rewire** every resource router `Depends(get_api_key)` → `Depends(require_principal)`; **`GET /meta`**
+  (`{edition:"oss", auth_modes:[…]}`); `app/routers/auth.py` shell; **shared user repository** (create/get-by-email/activate).
+- **R1** (code+security): `POST /auth/signup` {email,password} → 403 `domain_not_allowed` if domain not in allow-list,
+  409 if exists, else hash pw + create `pending` user + issue verification token + `Mailer.send`; 202
+  `{status:"pending_verification"}`. `POST /auth/verify` {token} → activate (`active`), 200 {user}. Owns
+  `app/auth/signup/*`, its routes in `auth.py`, tests.
+- **R2** (code+security): `POST /auth/login` {email,password} → verify hash (timing-safe) + user `active` → create
+  server-side session + `Set-Cookie: lavs_session` (HttpOnly, Secure, SameSite=Lax); `GET /auth/me` → principal (401 if none);
+  `POST /auth/logout` → clear session. **PasswordSessionProvider** (authenticates via session cookie) registered into the
+  resolver. Owns `app/auth/session/*`, its routes in `auth.py`, tests.
+- **TDD×(R1,R2)** (test-agent): unit+integration beside each lane, ≥ coverage floors.
+- **ATDD** (test-agent): full-flow acceptance (below).
+- **Aggregator/Gates/Debug**: as P0–P2; **auth-router overlap** (R1 signup/verify + R2 login/me/logout in `auth.py`)
+  resolved by unioning routes (pre-declared hazard).
+
+## 6. Convention enforcement
+1-class/file·snake_case (Gate A) · no constants→enum/config: `LAVS_AUTH_MODES`, statuses, cookie name (Gate A) ·
+`T|None`/no `cast`/`__init__.py` (Gate A + pyright) · **parameterized SQL** (Gate B) · **security invariants**
+(Gate B, see §7) · coverage floors (Gate C) · Conventional Commits + `#18` + **signed** (pre-PR).
+
+## 7. Test strategy & security invariants (Gate B — first-class)
+- **ATDD (before/parallel):** signup (allowed domain) → 202 pending → verify token → 200 active → login → session cookie →
+  `GET /auth/me` 200 → access a resource route 200 → logout → `/auth/me` 401. Negatives: disallowed domain → 403; duplicate
+  email → 409; login before verify → fails; bad token → fails; **API-key header still authenticates headless**; unauthenticated
+  resource access → 401 **when a provider is enabled**. `/meta` reports edition+auth_modes.
+- **TDD (with code):** per lane; mocks per `test-mocking-rules`; AAA.
+- **Gate B security invariants (must all hold):** argon2id password hashing (never plaintext/reversible) · session &
+  verification tokens are high-entropy (`secrets`), stored **hashed**, single-use/expiring · cookies `HttpOnly+Secure+SameSite=Lax`
+  · timing-safe secret comparisons · **no user enumeration** (generic signup/login errors) · parameterized SQL only · no secrets
+  logged · `require_principal` **fails closed when a provider is enabled**, open only when none configured (see §8 decision).
+
+## 8. Gap report & decisions to sanity-check
+| ID | Item | Decision / fallback |
+|---|---|---|
+| **G-P4a** | **New dep: password hashing** | **`argon2-cffi`** (argon2id; modern, strong). Flagged per conventions — pure-python-ish wheel, no system libs. (Alt: `bcrypt`.) |
+| **G-P4b** | Email transport | **In-process capture Mailer** for the pipeline (deterministic, no daemon); SMTP backend is a config swap. |
+| **G-P4c** | **Backward-compat vs "all routes require auth"** | `require_principal` **fails closed when any provider is enabled** (`LAVS_AUTH_MODES` non-empty / API key set) and is **open when nothing is configured** — mirroring today's API-key behavior. Keeps the **257 existing tests green** (no auth configured) while enforcing the contract in real deployments. Auth ATDD explicitly enables providers to assert 401s. |
+| **G-P4d** | Session store | Server-side `sessions` table in DuckDB; opaque token in HttpOnly cookie; token stored hashed; TTL-expiring. |
+| **G-P4e** | RBAC | Out of scope (v1 = authenticated⇒allowed); Principal shaped to accept org/role later. |
+| **G1/G2** | mutation testing / path drift | unchanged, documented. |
+| **A/B/C** | ATDD/env-runner/parallel-orchestration agents | test-agent mode / devops / harness. |
+
+## 9. Debug & retry
+`debug-agent`; failures surface at Gates A/B/C (Gate B is the gatekeeper for this phase); retry **failing lane only**,
+max 2×, with context injected; escalate on >2 retries, cross-cutting `auth.py`/resolver conflicts, an env blocker, or a
+security-invariant ambiguity. Pause + re-present on material change.
+
+---
+
+## Approval
+**On approval:** create `feat/18-p4-auth-oss` + Linear issues → run **env-setup** (incl. new hashing dep + capture Mailer) →
+build + gate **Foundation** → fan out **R1 + R2 + ATDD** (≤4 concurrent) each in its own worktree forking TDD → aggregate →
+enforcement → **security (heavyweight)** → integration + live E2E (signup→verify→login→me→resource→logout over real HTTP) →
+signed PR to `main` (#18).
+
+**Three decisions to confirm while reviewing** (all have sensible defaults above): (a) **`argon2-cffi`** as the new hashing
+dependency; (b) **fail-closed-when-configured, open-when-not** auth default (keeps existing tests green); (c) **in-process
+capture Mailer** instead of an external mail daemon. **Reply to approve, or redirect (incl. to P3).**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 description = "Add your description here"
 requires-python = ">=3.14"
 dependencies = [
+    "argon2-cffi>=25.1.0",
     "duckdb>=1.5.0",
     "fastapi>=0.135.1",
     "pydantic>=2.12.5",

--- a/tests/acceptance/_auth_support.py
+++ b/tests/acceptance/_auth_support.py
@@ -64,7 +64,10 @@ def auth_test_client(monkeypatch, *, api_key: str | None = None) -> Iterator[Tes
 
     from app.main import app
 
-    with TestClient(app, raise_server_exceptions=False) as client:
+    # Use an https base_url so the hardened ``Secure`` session cookie is carried
+    # by the client's cookie jar — httpx (correctly) withholds a Secure cookie
+    # over http, which is only a test-transport constraint, not app behaviour.
+    with TestClient(app, base_url="https://testserver", raise_server_exceptions=False) as client:
         yield client
 
 

--- a/tests/acceptance/_auth_support.py
+++ b/tests/acceptance/_auth_support.py
@@ -1,0 +1,147 @@
+"""Shared support for the P4 auth acceptance suite (not a collected test module).
+
+The leading underscore keeps pytest from collecting this file (see
+``python_files`` in ``pyproject.toml``). It provides the two things every auth
+scenario needs and that the global acceptance ``conftest`` deliberately does not:
+
+* an **env-configured, lifespan-active** :class:`~fastapi.testclient.TestClient`.
+  Auth is default-OPEN until a provider is configured, and the app reads its
+  :class:`~app.auth.auth_settings.AuthSettings` once at lifespan startup — so the
+  ``LAVS_AUTH_*`` environment must be set *before* the client enters its ``with``
+  block. :func:`auth_test_client` does exactly that.
+* small end-to-end helpers (signup, verification-token capture, verify, login)
+  so each scenario file stays behavior-focused (AAA).
+
+The ``/auth`` endpoints are authored by the R1/R2 lanes and are not present in
+this worktree yet; these helpers therefore drive the REAL routes and will go
+green once those lanes merge. Nothing here stubs an endpoint.
+"""
+
+import re
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from fastapi.testclient import TestClient
+
+# Deployment config that flips auth from default-OPEN to enforced. Password +
+# API-key providers, sign-ups restricted to a single allow-listed domain.
+AUTH_MODES = "password,apikey"
+ALLOWED_DOMAIN = "example.com"
+API_KEY = "acceptance-headless-key"
+SESSION_COOKIE_NAME = "lavs_session"
+
+# A password comfortably clearing any plausible strength floor R1 may impose.
+DEFAULT_PASSWORD = "Acceptance-Pass-123!"
+
+# ``secrets.token_urlsafe`` verification tokens are runs of URL-safe characters;
+# the raw token is delivered once, in the email body captured by the mailer.
+_TOKEN_QUERY_RE = re.compile(r"token=([A-Za-z0-9_-]+)")
+_TOKEN_RUN_RE = re.compile(r"[A-Za-z0-9_-]{20,}")
+
+
+@contextmanager
+def auth_test_client(monkeypatch, *, api_key: str | None = None) -> Iterator[TestClient]:
+    """Yield a lifespan-active client with the auth providers configured.
+
+    The ``LAVS_AUTH_*`` environment is set before the client is constructed so
+    the lifespan reads an enforced (fail-closed) configuration.
+
+    Args:
+        monkeypatch: The pytest ``monkeypatch`` fixture (auto-undone on teardown).
+        api_key: When provided, the headless ``X-API-Key`` credential to
+            configure; when ``None`` no API key is configured.
+
+    Yields:
+        A :class:`~fastapi.testclient.TestClient` whose lifespan has run.
+    """
+    monkeypatch.setenv("LAVS_AUTH_MODES", AUTH_MODES)
+    monkeypatch.setenv("LAVS_ALLOWED_EMAIL_DOMAINS", ALLOWED_DOMAIN)
+    if api_key is not None:
+        monkeypatch.setenv("LAVS_API_KEY", api_key)
+    else:
+        monkeypatch.delenv("LAVS_API_KEY", raising=False)
+
+    from app.main import app
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+
+
+def unique_email(local: str = "engineer", domain: str = ALLOWED_DOMAIN) -> str:
+    """Return a collision-free email in ``domain`` (defaults to the allow-list)."""
+    return f"{local}-{uuid.uuid4().hex[:12]}@{domain}"
+
+
+def verification_token_for(client: TestClient, email: str) -> str:
+    """Recover the raw verification token from the captured email for ``email``.
+
+    Args:
+        client: The lifespan-active client (its ``app.state.mailer`` is the sink).
+        email: The recipient whose most recent verification email to read.
+
+    Returns:
+        The raw verification token to POST to ``/auth/verify``.
+    """
+    mailer = client.app.state.mailer
+    message = mailer.last_for(email)
+    assert message is not None, f"no verification email was captured for {email!r}"
+
+    query_match = _TOKEN_QUERY_RE.search(message.body)
+    if query_match is not None:
+        return query_match.group(1)
+
+    candidates = _TOKEN_RUN_RE.findall(message.body)
+    assert candidates, f"no token-shaped value found in email body: {message.body!r}"
+    return max(candidates, key=len)
+
+
+def signup(client: TestClient, email: str, password: str = DEFAULT_PASSWORD):
+    """POST ``/auth/signup`` and return the raw response."""
+    return client.post("/auth/signup", json={"email": email, "password": password})
+
+
+def signup_and_verify(client: TestClient, email: str, password: str = DEFAULT_PASSWORD):
+    """Run the full sign-up + email-verification flow, asserting each hop.
+
+    Args:
+        client: The lifespan-active client.
+        email: The email to register (must be on the allow-listed domain).
+        password: The password to register.
+
+    Returns:
+        The ``/auth/verify`` response (200 with the activated user body).
+    """
+    signup_response = signup(client, email, password)
+    assert signup_response.status_code == 202, signup_response.text
+
+    token = verification_token_for(client, email)
+    verify_response = client.post("/auth/verify", json={"token": token})
+    assert verify_response.status_code == 200, verify_response.text
+    return verify_response
+
+
+def login(client: TestClient, email: str, password: str = DEFAULT_PASSWORD):
+    """POST ``/auth/login`` and return the raw response."""
+    return client.post("/auth/login", json={"email": email, "password": password})
+
+
+def assert_error_envelope(payload: object, expected_code: str) -> None:
+    """Assert ``payload`` is the uniform ``{"error": {...}}`` envelope.
+
+    Args:
+        payload: The parsed JSON response body.
+        expected_code: The stable machine-readable ``code`` that must be present.
+    """
+    assert isinstance(payload, dict), f"error body must be a JSON object; got {type(payload)}"
+    assert "error" in payload, f"error body must be wrapped in an 'error' key; got {payload}"
+    error = payload["error"]
+    assert isinstance(error, dict), "the 'error' value must be an object"
+    assert set(error) >= {"code", "message", "details"}, (
+        f"error object must carry code/message/details; got keys {set(error)}"
+    )
+    assert error["code"] == expected_code, (
+        f"expected error code {expected_code!r}; got {error['code']!r}"
+    )
+    assert isinstance(error["message"], str) and error["message"]
+    assert isinstance(error["details"], dict)

--- a/tests/acceptance/test_auth_enforcement.py
+++ b/tests/acceptance/test_auth_enforcement.py
@@ -1,0 +1,80 @@
+"""Acceptance: resource routes fail closed once auth is configured (API_CONTRACT §1).
+
+Proves the ``require_principal`` gate on a representative resource route
+(``GET /products``): with providers configured, a credential-less request is
+rejected 401, while the *same* request carrying a valid credential succeeds 200.
+Two credential kinds are exercised — the headless ``X-API-Key`` (works today via
+the foundation's API-key provider) and the browser ``lavs_session`` cookie
+minted by login (R2). A wrong API key is rejected, confirming the gate is not
+merely presence-checking a header.
+
+The API-key and unauthenticated scenarios pass against the current foundation;
+the session-cookie scenario depends on the R2 login lane and is expected RED
+until it merges.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.acceptance._auth_support import (
+    API_KEY,
+    assert_error_envelope,
+    auth_test_client,
+    login,
+    signup_and_verify,
+    unique_email,
+)
+
+_RESOURCE_ROUTE = "/products"
+
+
+@pytest.fixture
+def auth_client(monkeypatch, test_db: str):
+    """A lifespan-active client with password + API-key auth both configured."""
+    with auth_test_client(monkeypatch, api_key=API_KEY) as client:
+        yield client
+
+
+class TestResourceEnforcement:
+    """A configured deployment rejects anonymous access and admits valid credentials."""
+
+    def test_unauthenticated_request_is_rejected(self, auth_client: TestClient) -> None:
+        """With auth configured, a credential-less resource request is 401."""
+        # Act
+        response = auth_client.get(_RESOURCE_ROUTE)
+
+        # Assert
+        assert response.status_code == 401, response.text
+        assert_error_envelope(response.json(), "unauthorized")
+
+    def test_valid_api_key_grants_access(self, auth_client: TestClient) -> None:
+        """The configured ``X-API-Key`` authenticates a headless request 200."""
+        # Act
+        response = auth_client.get(_RESOURCE_ROUTE, headers={"X-API-Key": API_KEY})
+
+        # Assert
+        assert response.status_code == 200, response.text
+        assert isinstance(response.json(), list)
+
+    def test_wrong_api_key_is_rejected(self, auth_client: TestClient) -> None:
+        """A non-matching ``X-API-Key`` is rejected 401 (not merely header-present)."""
+        # Act
+        response = auth_client.get(_RESOURCE_ROUTE, headers={"X-API-Key": "not-the-key"})
+
+        # Assert
+        assert response.status_code == 401, response.text
+        assert_error_envelope(response.json(), "unauthorized")
+
+    def test_valid_session_cookie_grants_access(self, auth_client: TestClient) -> None:
+        """A logged-in user's session cookie authenticates the same resource route 200."""
+        # Arrange
+        email = unique_email()
+        signup_and_verify(auth_client, email)
+        assert login(auth_client, email).status_code == 200
+
+        # Act — the client replays the session cookie from login automatically
+        response = auth_client.get(_RESOURCE_ROUTE)
+
+        # Assert
+        assert response.status_code == 200, response.text
+        assert isinstance(response.json(), list)

--- a/tests/acceptance/test_auth_foundation.py
+++ b/tests/acceptance/test_auth_foundation.py
@@ -1,0 +1,93 @@
+"""Acceptance: the P4 auth foundation is wired end to end.
+
+Drives the real application (via the lifespan-active ``client`` fixture) to prove
+the foundation boots: health is up, the auth spine and mailer are on
+``app.state``, the auth tables exist, ``/meta`` advertises the deployment, a
+resource route stays open when nothing is configured, and — with a configured
+resolver — the same route fails closed with a 401 envelope.
+"""
+
+from fastapi.testclient import TestClient
+
+from app.auth.auth_mode import AuthMode
+from app.auth.auth_resolver import AuthResolver
+from app.auth.auth_resolver_factory import AuthResolverFactory
+from app.auth.auth_settings import AuthSettings
+
+_AUTH_TABLES = {"users", "sessions", "email_verification_tokens"}
+
+
+class TestFoundationBoot:
+    """Startup wiring and public surface."""
+
+    def test_health_is_ok(self, client: TestClient) -> None:
+        """The liveness probe answers 200."""
+        # Act
+        response = client.get("/health")
+
+        # Assert
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+
+    def test_app_state_has_resolver_and_mailer(self, client: TestClient) -> None:
+        """The lifespan populated the auth resolver and the capture mailer."""
+        # Act
+        state = client.app.state
+
+        # Assert
+        assert isinstance(state.auth_resolver, AuthResolver)
+        assert state.mailer is not None
+        assert state.auth_registry is not None
+
+    def test_auth_tables_exist(self, client: TestClient) -> None:
+        """The users/sessions/verification tables were created at startup."""
+        # Arrange
+        connection = client.app.state.db_connection
+
+        # Act
+        rows = connection.execute("SHOW ALL TABLES").fetchall()
+        table_names = {row[2] for row in rows}
+
+        # Assert
+        assert _AUTH_TABLES.issubset(table_names)
+
+    def test_meta_reports_edition_and_modes(self, client: TestClient) -> None:
+        """``GET /meta`` is public and reports edition + auth modes."""
+        # Act
+        response = client.get("/meta")
+
+        # Assert
+        assert response.status_code == 200
+        body = response.json()
+        assert body["edition"] == "oss"
+        assert isinstance(body["auth_modes"], list)
+
+
+class TestFoundationAuthGate:
+    """Open-when-unconfigured vs fail-closed-when-configured."""
+
+    def test_resource_route_open_when_unconfigured(self, client: TestClient) -> None:
+        """With no auth configured, a resource route is reachable with no creds."""
+        # Act
+        response = client.get("/products")
+
+        # Assert
+        assert response.status_code == 200
+
+    def test_resource_route_fail_closed_when_configured(self, client: TestClient) -> None:
+        """A password-configured resolver rejects a credential-less request 401."""
+        # Arrange — swap in a configured resolver (env plumbing in-test is awkward)
+        app = client.app
+        original = app.state.auth_resolver
+        settings = AuthSettings(modes={AuthMode.PASSWORD})
+        app.state.auth_resolver = AuthResolverFactory.build_resolver(settings)
+
+        try:
+            # Act
+            response = client.get("/products")
+
+            # Assert
+            assert response.status_code == 401
+            assert response.json()["error"]["code"] == "unauthorized"
+        finally:
+            app.state.auth_resolver = original

--- a/tests/acceptance/test_auth_login_session.py
+++ b/tests/acceptance/test_auth_login_session.py
@@ -1,0 +1,126 @@
+"""Acceptance: OSS login, session cookie, and logout (API_CONTRACT §2).
+
+Drives the REAL ``/auth/login``, ``/auth/me``, and ``/auth/logout`` endpoints
+against a verified user. The happy path proves login mints an ``HttpOnly``
+``lavs_session`` cookie (flags asserted off the raw ``Set-Cookie`` header), that
+``/auth/me`` accepts the cookie, and that logout invalidates the session so a
+subsequent ``/auth/me`` is 401. Negatives pin fail-closed, non-enumerating
+behaviour: logging in before verification and logging in with the wrong password
+both return the *same* generic 401 (so a caller cannot distinguish "no such
+user" from "bad password").
+
+The ``/auth`` login/session endpoints are built by the R2 lane and are not in
+this worktree yet, so these scenarios are expected to be RED until R2 merges.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.acceptance._auth_support import (
+    SESSION_COOKIE_NAME,
+    assert_error_envelope,
+    auth_test_client,
+    login,
+    signup,
+    signup_and_verify,
+    unique_email,
+)
+
+
+@pytest.fixture
+def auth_client(monkeypatch, test_db: str):
+    """A lifespan-active client with password auth + the ``example.com`` allow-list."""
+    with auth_test_client(monkeypatch) as client:
+        yield client
+
+
+def _session_set_cookie(response) -> str:
+    """Return the ``Set-Cookie`` header line that sets the session cookie."""
+    cookie_headers = response.headers.get_list("set-cookie")
+    for header in cookie_headers:
+        if header.startswith(f"{SESSION_COOKIE_NAME}="):
+            return header
+    raise AssertionError(
+        f"no {SESSION_COOKIE_NAME} Set-Cookie header on login response; got {cookie_headers}"
+    )
+
+
+class TestLoginSession:
+    """Login establishes an HttpOnly session that /auth/me honours and logout ends."""
+
+    def test_login_sets_httponly_samesite_session_cookie(self, auth_client: TestClient) -> None:
+        """A verified login returns 200 and a hardened ``lavs_session`` cookie."""
+        # Arrange
+        email = unique_email()
+        signup_and_verify(auth_client, email)
+
+        # Act
+        response = login(auth_client, email)
+
+        # Assert
+        assert response.status_code == 200, response.text
+        set_cookie = _session_set_cookie(response)
+        assert "httponly" in set_cookie.lower(), set_cookie
+        assert "samesite" in set_cookie.lower(), set_cookie
+
+    def test_me_with_session_cookie_returns_the_user(self, auth_client: TestClient) -> None:
+        """The session cookie from login authenticates a follow-up ``GET /auth/me``."""
+        # Arrange
+        email = unique_email()
+        signup_and_verify(auth_client, email)
+        login_response = login(auth_client, email)
+        assert login_response.status_code == 200, login_response.text
+
+        # Act — the client's cookie jar replays the session cookie automatically
+        response = auth_client.get("/auth/me")
+
+        # Assert
+        assert response.status_code == 200, response.text
+        assert response.json()["email"] == email
+
+    def test_logout_invalidates_the_session(self, auth_client: TestClient) -> None:
+        """After logout the previously good session no longer authenticates /auth/me."""
+        # Arrange
+        email = unique_email()
+        signup_and_verify(auth_client, email)
+        assert login(auth_client, email).status_code == 200
+
+        # Act
+        logout_response = auth_client.post("/auth/logout")
+        me_response = auth_client.get("/auth/me")
+
+        # Assert
+        assert logout_response.status_code in (200, 204), logout_response.text
+        assert me_response.status_code == 401, me_response.text
+        assert_error_envelope(me_response.json(), "unauthorized")
+
+    def test_login_before_verification_returns_401(self, auth_client: TestClient) -> None:
+        """A pending (unverified) user cannot log in — generic 401."""
+        # Arrange
+        email = unique_email()
+        assert signup(auth_client, email).status_code == 202
+
+        # Act
+        response = login(auth_client, email)
+
+        # Assert
+        assert response.status_code == 401, response.text
+        assert_error_envelope(response.json(), "unauthorized")
+
+    def test_wrong_password_and_unknown_email_are_indistinguishable(
+        self, auth_client: TestClient
+    ) -> None:
+        """Wrong password and unknown email return the identical generic 401 shape."""
+        # Arrange
+        email = unique_email()
+        signup_and_verify(auth_client, email)
+
+        # Act
+        wrong_password = login(auth_client, email, password="Totally-Wrong-1!")
+        unknown_email = login(auth_client, unique_email(local="ghost"))
+
+        # Assert — no account enumeration: same status and same envelope code
+        assert wrong_password.status_code == 401, wrong_password.text
+        assert unknown_email.status_code == 401, unknown_email.text
+        assert_error_envelope(wrong_password.json(), "unauthorized")
+        assert_error_envelope(unknown_email.json(), "unauthorized")

--- a/tests/acceptance/test_auth_meta.py
+++ b/tests/acceptance/test_auth_meta.py
@@ -1,0 +1,46 @@
+"""Acceptance: the public ``GET /meta`` capability endpoint (API_CONTRACT §1, §8).
+
+``/meta`` is what the UI reads *before* a principal exists to decide which login
+to render, so it must be reachable with no credentials even on a fully-configured
+deployment, and it must advertise the edition and the enabled auth modes. This
+suite configures ``password,apikey`` and asserts both modes surface and that the
+edition is ``oss`` — and that the endpoint needs no auth.
+
+``/meta`` ships with the foundation, so these scenarios are expected to pass now.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.acceptance._auth_support import API_KEY, auth_test_client
+
+
+@pytest.fixture
+def auth_client(monkeypatch, test_db: str):
+    """A lifespan-active client with password + API-key auth both configured."""
+    with auth_test_client(monkeypatch, api_key=API_KEY) as client:
+        yield client
+
+
+class TestMeta:
+    """The capability descriptor is public and reflects the configured modes."""
+
+    def test_meta_reports_oss_edition_and_enabled_modes(self, auth_client: TestClient) -> None:
+        """``GET /meta`` returns 200 with edition ``oss`` and the enabled modes."""
+        # Act
+        response = auth_client.get("/meta")
+
+        # Assert
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["edition"] == "oss"
+        assert isinstance(body["auth_modes"], list)
+        assert set(body["auth_modes"]) >= {"password", "apikey"}
+
+    def test_meta_requires_no_authentication(self, auth_client: TestClient) -> None:
+        """``/meta`` stays public even with providers configured and no credentials."""
+        # Act — no cookie, no API key, yet auth is configured on this deployment
+        response = auth_client.get("/meta")
+
+        # Assert
+        assert response.status_code == 200, response.text

--- a/tests/acceptance/test_auth_signup_verify.py
+++ b/tests/acceptance/test_auth_signup_verify.py
@@ -1,0 +1,93 @@
+"""Acceptance: OSS sign-up + email/domain verification (API_CONTRACT §2).
+
+Drives the REAL ``/auth/signup`` and ``/auth/verify`` endpoints end to end with
+the auth providers configured (default-OPEN otherwise). Happy path: an
+allow-listed domain signs up to a ``pending_verification`` state, the
+verification token is recovered from the captured email, and posting it
+activates the user. Negatives pin the contract's failure codes: a disallowed
+domain is ``403 domain_not_allowed`` and a duplicate email is ``409 conflict``,
+each as the uniform error envelope.
+
+These endpoints are built by the R1 lane and are not in this worktree yet, so
+every scenario here is expected to be RED (route missing) until R1 merges.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth.users.user_status import UserStatus
+from tests.acceptance._auth_support import (
+    assert_error_envelope,
+    auth_test_client,
+    signup,
+    unique_email,
+    verification_token_for,
+)
+
+
+@pytest.fixture
+def auth_client(monkeypatch, test_db: str):
+    """A lifespan-active client with password auth + the ``example.com`` allow-list."""
+    with auth_test_client(monkeypatch) as client:
+        yield client
+
+
+class TestSignupVerify:
+    """Sign-up establishes a pending user; verification activates it."""
+
+    def test_signup_allowed_domain_returns_202_pending(self, auth_client: TestClient) -> None:
+        """An allow-listed sign-up is accepted 202 in a pending-verification state."""
+        # Arrange
+        email = unique_email()
+
+        # Act
+        response = signup(auth_client, email)
+
+        # Assert
+        assert response.status_code == 202, response.text
+        assert response.json()["status"] == "pending_verification"
+
+    def test_verify_activates_the_pending_user(self, auth_client: TestClient) -> None:
+        """Posting the emailed token flips the user to active and returns 200 {user}."""
+        # Arrange
+        email = unique_email()
+        signup_response = signup(auth_client, email)
+        assert signup_response.status_code == 202, signup_response.text
+        token = verification_token_for(auth_client, email)
+
+        # Act
+        response = auth_client.post("/auth/verify", json={"token": token})
+
+        # Assert
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["email"] == email
+        assert body["status"] == UserStatus.ACTIVE.value
+
+    def test_signup_disallowed_domain_returns_403_domain_not_allowed(
+        self, auth_client: TestClient
+    ) -> None:
+        """A sign-up outside the allow-list is refused 403 with a domain envelope."""
+        # Arrange
+        email = unique_email(domain="not-allowed.org")
+
+        # Act
+        response = signup(auth_client, email)
+
+        # Assert
+        assert response.status_code == 403, response.text
+        assert_error_envelope(response.json(), "domain_not_allowed")
+
+    def test_duplicate_email_returns_409_conflict(self, auth_client: TestClient) -> None:
+        """Registering an email that already exists is a 409 conflict envelope."""
+        # Arrange
+        email = unique_email()
+        first = signup(auth_client, email)
+        assert first.status_code == 202, first.text
+
+        # Act
+        duplicate = signup(auth_client, email)
+
+        # Assert
+        assert duplicate.status_code == 409, duplicate.text
+        assert_error_envelope(duplicate.json(), "conflict")

--- a/tests/configurations/test_database_config.py
+++ b/tests/configurations/test_database_config.py
@@ -16,6 +16,9 @@ def test_database_config_lists_core_tables() -> None:
         "versions",
         "releases",
         "release_components",
+        "users",
+        "sessions",
+        "email_verification_tokens",
     ]
 
 
@@ -38,6 +41,17 @@ def test_release_components_follows_releases() -> None:
 
     # Assert
     assert names.index("releases") < names.index("release_components")
+
+
+def test_users_precede_their_child_tables() -> None:
+    """sessions and email_verification_tokens must follow users so drops honour FKs."""
+    # Act
+    config = load_database_config()
+    names = [table.name for table in config.database.tables]
+
+    # Assert
+    assert names.index("users") < names.index("sessions")
+    assert names.index("users") < names.index("email_verification_tokens")
 
 
 def test_versions_table_declares_status_field() -> None:

--- a/tests/integration/routers/test_login.py
+++ b/tests/integration/routers/test_login.py
@@ -1,0 +1,206 @@
+"""Integration tests for the ``/auth`` login/session/me/logout routes.
+
+Exercises the full FastAPI stack with the ``password`` auth mode enabled so the
+:class:`~app.auth.providers.password_session_provider.PasswordSessionProvider`
+is registered and the resolver fails closed. Each test enters the application
+lifespan (``with TestClient(app)``) so the managed DuckDB connection and the
+auth spine are wired exactly as in production, and seeds users directly on that
+managed connection (sign-up lives in the sibling R1 lane).
+"""
+
+import contextlib
+from collections.abc import Iterator
+
+import duckdb
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth.password_hasher import PasswordHasher
+from app.auth.session.session_cookie import SessionCookie
+from app.auth.users.user_status import UserStatus
+from app.models.types.ulid_id import new_ulid
+
+_PASSWORD = "correct horse battery staple"
+
+
+def _seed_user(conn: duckdb.DuckDBPyConnection, email: str, status: UserStatus) -> str:
+    """Insert a user with a known password and return its id."""
+    user_id = new_ulid()
+    conn.execute(
+        "INSERT INTO users (id, email, password_hash, status, edition) VALUES (?, ?, ?, ?, ?)",
+        [user_id, email, PasswordHasher().hash_password(_PASSWORD), status.value, "oss"],
+    )
+    return user_id
+
+
+@contextlib.contextmanager
+def _password_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """Yield a lifespan-entered client with the ``password`` mode enabled."""
+    monkeypatch.setenv("LAVS_AUTH_MODES", "password")
+    from app.main import app
+
+    with TestClient(app) as client:
+        yield client
+
+
+def _login_token(response_headers: dict[str, str]) -> str:
+    """Extract the raw session token from a login response's Set-Cookie."""
+    set_cookie = response_headers["set-cookie"]
+    return set_cookie.split(f"{SessionCookie.NAME}=")[1].split(";")[0]
+
+
+class TestLogin:
+    """``POST /auth/login``."""
+
+    def test_active_user_logs_in_and_sets_secure_cookie(
+        self, test_db: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A correct credential returns 200 with a hardened session cookie."""
+        with _password_client(monkeypatch) as client:
+            # Arrange
+            from app.main import app
+
+            _seed_user(app.state.db_connection, "active@example.com", UserStatus.ACTIVE)
+
+            # Act
+            response = client.post(
+                "/auth/login", json={"email": "active@example.com", "password": _PASSWORD}
+            )
+
+            # Assert
+            assert response.status_code == 200
+            body = response.json()
+            assert body["email"] == "active@example.com"
+            assert body["status"] == UserStatus.ACTIVE.value
+            assert "password_hash" not in body
+            set_cookie = response.headers["set-cookie"]
+            assert f"{SessionCookie.NAME}=" in set_cookie
+            assert "HttpOnly" in set_cookie
+            assert "Secure" in set_cookie
+            assert "SameSite=lax" in set_cookie
+            assert "Path=/" in set_cookie
+
+    def test_wrong_password_returns_generic_401(
+        self, test_db: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A wrong password yields a generic 401 and no cookie."""
+        with _password_client(monkeypatch) as client:
+            # Arrange
+            from app.main import app
+
+            _seed_user(app.state.db_connection, "active@example.com", UserStatus.ACTIVE)
+
+            # Act
+            response = client.post(
+                "/auth/login", json={"email": "active@example.com", "password": "wrong"}
+            )
+
+            # Assert
+            assert response.status_code == 401
+            assert response.json()["error"]["message"] == "invalid credentials"
+            assert "set-cookie" not in response.headers
+
+    def test_unknown_email_returns_same_generic_401(
+        self, test_db: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unknown email is indistinguishable from a wrong password."""
+        with _password_client(monkeypatch) as client:
+            # Act
+            response = client.post(
+                "/auth/login", json={"email": "nobody@example.com", "password": _PASSWORD}
+            )
+
+            # Assert
+            assert response.status_code == 401
+            assert response.json()["error"]["message"] == "invalid credentials"
+
+    def test_pending_user_returns_generic_401(
+        self, test_db: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unverified (pending) account cannot log in, without revealing why."""
+        with _password_client(monkeypatch) as client:
+            # Arrange
+            from app.main import app
+
+            _seed_user(app.state.db_connection, "pending@example.com", UserStatus.PENDING)
+
+            # Act
+            response = client.post(
+                "/auth/login", json={"email": "pending@example.com", "password": _PASSWORD}
+            )
+
+            # Assert
+            assert response.status_code == 401
+            assert response.json()["error"]["message"] == "invalid credentials"
+
+    def test_disabled_user_returns_generic_401(
+        self, test_db: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A disabled account cannot log in."""
+        with _password_client(monkeypatch) as client:
+            # Arrange
+            from app.main import app
+
+            _seed_user(app.state.db_connection, "disabled@example.com", UserStatus.DISABLED)
+
+            # Act
+            response = client.post(
+                "/auth/login", json={"email": "disabled@example.com", "password": _PASSWORD}
+            )
+
+            # Assert
+            assert response.status_code == 401
+
+
+class TestSessionRoundTrip:
+    """Login → /me → resource → logout → /me."""
+
+    def test_full_session_lifecycle(self, test_db: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A cookie authenticates /me and resources, and logout revokes it."""
+        with _password_client(monkeypatch) as client:
+            # Arrange
+            from app.main import app
+
+            _seed_user(app.state.db_connection, "active@example.com", UserStatus.ACTIVE)
+            login = client.post(
+                "/auth/login", json={"email": "active@example.com", "password": _PASSWORD}
+            )
+            token = _login_token(login.headers)
+            cookies = {SessionCookie.NAME: token}
+
+            # Act / Assert — the cookie authenticates /me...
+            me = client.get("/auth/me", cookies=cookies)
+            assert me.status_code == 200
+            assert me.json()["email"] == "active@example.com"
+
+            # ...and a protected resource route...
+            resource = client.get("/products", cookies=cookies)
+            assert resource.status_code == 200
+
+            # ...logout revokes the session...
+            logout = client.post("/auth/logout", cookies=cookies)
+            assert logout.status_code == 204
+
+            # ...after which the same cookie no longer authenticates.
+            me_after = client.get("/auth/me", cookies=cookies)
+            assert me_after.status_code == 401
+
+    def test_me_without_cookie_is_401(self, test_db: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unauthenticated /me request is rejected with 401."""
+        with _password_client(monkeypatch) as client:
+            # Act
+            response = client.get("/auth/me")
+
+            # Assert
+            assert response.status_code == 401
+
+    def test_logout_without_cookie_is_idempotent(
+        self, test_db: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Logout succeeds even when no session cookie is present."""
+        with _password_client(monkeypatch) as client:
+            # Act
+            response = client.post("/auth/logout")
+
+            # Assert
+            assert response.status_code == 204

--- a/tests/integration/routers/test_signup.py
+++ b/tests/integration/routers/test_signup.py
@@ -1,0 +1,170 @@
+"""Integration tests for the ``/auth/signup`` and ``/auth/verify`` routes.
+
+Exercises the full FastAPI stack (routing, dependency-injected managed DuckDB
+connection and mailer, service execution, and the error-envelope handlers). The
+client is entered as a context manager so the application lifespan runs and
+populates ``app.state`` (DB connection + capture mailer); the raw verification
+token is recovered straight from the in-memory mailer.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.mail.capture_mailer import CaptureMailer
+
+
+@pytest.fixture()
+def signup_client(test_db: str) -> Iterator[TestClient]:
+    """Yield a lifespan-active client over the per-test temporary database."""
+    from app.main import app
+
+    with TestClient(app) as client:
+        yield client
+
+
+def _captured_token(client: TestClient, email: str) -> str:
+    """Recover the raw verification token emailed to ``email``."""
+    mailer = client.app.state.mailer
+    assert isinstance(mailer, CaptureMailer)
+    message = mailer.last_for(email)
+    assert message is not None
+    lines = [line.strip() for line in message.body.splitlines() if line.strip()]
+    return next(line for line in lines if " " not in line)
+
+
+class TestSignup:
+    """``POST /auth/signup``."""
+
+    def test_signup_returns_202_pending(self, signup_client: TestClient) -> None:
+        """A valid sign-up is accepted with a pending-verification status."""
+        # Act
+        response = signup_client.post(
+            "/auth/signup",
+            json={"email": "engineer@example.com", "password": "correct horse battery"},
+        )
+
+        # Assert
+        assert response.status_code == 202
+        assert response.json() == {"status": "pending_verification"}
+
+    def test_signup_emails_a_token(self, signup_client: TestClient) -> None:
+        """Sign-up sends exactly one email carrying a usable token."""
+        # Act
+        signup_client.post(
+            "/auth/signup",
+            json={"email": "engineer@example.com", "password": "correct horse battery"},
+        )
+
+        # Assert
+        token = _captured_token(signup_client, "engineer@example.com")
+        assert len(token) > 0
+
+    def test_duplicate_email_returns_409(self, signup_client: TestClient) -> None:
+        """A repeated address yields a 409 conflict envelope."""
+        # Arrange
+        body = {"email": "dupe@example.com", "password": "correct horse battery"}
+        signup_client.post("/auth/signup", json=body)
+
+        # Act
+        response = signup_client.post("/auth/signup", json=body)
+
+        # Assert
+        assert response.status_code == 409
+        assert response.json()["error"]["code"] == "conflict"
+
+    def test_malformed_email_returns_422(self, signup_client: TestClient) -> None:
+        """A malformed address is rejected before any persistence."""
+        # Act
+        response = signup_client.post(
+            "/auth/signup",
+            json={"email": "not-an-email", "password": "correct horse battery"},
+        )
+
+        # Assert
+        assert response.status_code == 422
+
+
+class TestVerify:
+    """``POST /auth/verify``."""
+
+    def test_verify_activates_user(self, signup_client: TestClient) -> None:
+        """A captured token verifies the account and returns it active."""
+        # Arrange
+        signup_client.post(
+            "/auth/signup",
+            json={"email": "engineer@example.com", "password": "correct horse battery"},
+        )
+        token = _captured_token(signup_client, "engineer@example.com")
+
+        # Act
+        response = signup_client.post("/auth/verify", json={"token": token})
+
+        # Assert
+        assert response.status_code == 200
+        body = response.json()
+        assert body["email"] == "engineer@example.com"
+        assert body["status"] == "active"
+        assert "password_hash" not in body
+
+    def test_verify_is_single_use(self, signup_client: TestClient) -> None:
+        """A token cannot be redeemed twice."""
+        # Arrange
+        signup_client.post(
+            "/auth/signup",
+            json={"email": "engineer@example.com", "password": "correct horse battery"},
+        )
+        token = _captured_token(signup_client, "engineer@example.com")
+        signup_client.post("/auth/verify", json={"token": token})
+
+        # Act
+        response = signup_client.post("/auth/verify", json={"token": token})
+
+        # Assert
+        assert response.status_code == 404
+
+    def test_verify_unknown_token_returns_404(self, signup_client: TestClient) -> None:
+        """An unknown token yields a generic not-found envelope (no enumeration)."""
+        # Act
+        response = signup_client.post("/auth/verify", json={"token": "never-issued"})
+
+        # Assert
+        assert response.status_code == 404
+
+
+class TestSignupDomainAllowList:
+    """Domain allow-list enforcement via ``LAVS_ALLOWED_EMAIL_DOMAINS``."""
+
+    def test_disallowed_domain_returns_403(
+        self, signup_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A domain outside a configured allow-list is forbidden."""
+        # Arrange
+        monkeypatch.setenv("LAVS_ALLOWED_EMAIL_DOMAINS", "allowed.com")
+
+        # Act
+        response = signup_client.post(
+            "/auth/signup",
+            json={"email": "engineer@example.com", "password": "correct horse battery"},
+        )
+
+        # Assert
+        assert response.status_code == 403
+        assert response.json()["error"]["code"] == "domain_not_allowed"
+
+    def test_allowed_domain_passes(
+        self, signup_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A domain on the allow-list is accepted."""
+        # Arrange
+        monkeypatch.setenv("LAVS_ALLOWED_EMAIL_DOMAINS", "example.com")
+
+        # Act
+        response = signup_client.post(
+            "/auth/signup",
+            json={"email": "engineer@example.com", "password": "correct horse battery"},
+        )
+
+        # Assert
+        assert response.status_code == 202

--- a/tests/unit/auth/__init__.py
+++ b/tests/unit/auth/__init__.py
@@ -1,0 +1,1 @@
+"""tests/unit/auth tests."""

--- a/tests/unit/auth/providers/__init__.py
+++ b/tests/unit/auth/providers/__init__.py
@@ -1,0 +1,1 @@
+"""tests/unit/auth/providers tests."""

--- a/tests/unit/auth/providers/test_api_key_provider.py
+++ b/tests/unit/auth/providers/test_api_key_provider.py
@@ -1,0 +1,78 @@
+"""Unit tests for :class:`ApiKeyProvider`."""
+
+from unittest import IsolatedAsyncioTestCase
+
+from fastapi import Request
+
+from app.auth.principal_kind import PrincipalKind
+from app.auth.providers.api_key_provider import ApiKeyProvider
+from app.auth.service_identity import ServiceIdentity
+from app.security.api_key import API_KEY_ENV_VAR, API_KEY_HEADER
+
+
+def _request_with_headers(headers: dict[str, str]) -> Request:
+    """Build a request carrying the given headers."""
+    raw = [(key.lower().encode(), value.encode()) for key, value in headers.items()]
+    scope = {"type": "http", "method": "GET", "path": "/", "headers": raw}
+    return Request(scope)
+
+
+class TestApiKeyProvider(IsolatedAsyncioTestCase):
+    """Header-based API-key authentication."""
+
+    def setUp(self) -> None:
+        """Record and clear the API-key environment variable."""
+        import os
+
+        self._os = os
+        self._saved = os.environ.get(API_KEY_ENV_VAR)
+        os.environ.pop(API_KEY_ENV_VAR, None)
+        self._provider = ApiKeyProvider(edition="oss")
+
+    def tearDown(self) -> None:
+        """Restore the API-key environment variable."""
+        if self._saved is None:
+            self._os.environ.pop(API_KEY_ENV_VAR, None)
+        else:
+            self._os.environ[API_KEY_ENV_VAR] = self._saved
+
+    async def test_no_configured_key_returns_none(self) -> None:
+        """With no key configured the provider declines every request."""
+        # Arrange
+        request = _request_with_headers({API_KEY_HEADER: "anything"})
+
+        # Act / Assert
+        assert await self._provider.authenticate(request) is None
+
+    async def test_matching_key_returns_service_principal(self) -> None:
+        """A correct key yields the ``api-key`` service principal."""
+        # Arrange
+        self._os.environ[API_KEY_ENV_VAR] = "top-secret"
+        request = _request_with_headers({API_KEY_HEADER: "top-secret"})
+
+        # Act
+        principal = await self._provider.authenticate(request)
+
+        # Assert
+        assert principal is not None
+        assert principal.kind is PrincipalKind.SERVICE
+        assert principal.id == ServiceIdentity.API_KEY.value
+        assert principal.edition == "oss"
+
+    async def test_wrong_key_returns_none(self) -> None:
+        """An incorrect key is not authenticated."""
+        # Arrange
+        self._os.environ[API_KEY_ENV_VAR] = "top-secret"
+        request = _request_with_headers({API_KEY_HEADER: "guess"})
+
+        # Act / Assert
+        assert await self._provider.authenticate(request) is None
+
+    async def test_missing_header_returns_none(self) -> None:
+        """A configured key with no header present is not authenticated."""
+        # Arrange
+        self._os.environ[API_KEY_ENV_VAR] = "top-secret"
+        request = _request_with_headers({})
+
+        # Act / Assert
+        assert await self._provider.authenticate(request) is None

--- a/tests/unit/auth/providers/test_password_session_provider.py
+++ b/tests/unit/auth/providers/test_password_session_provider.py
@@ -1,0 +1,111 @@
+"""Unit tests for :class:`PasswordSessionProvider`."""
+
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+
+import duckdb
+from fastapi import Request
+
+from app.auth.principal_kind import PrincipalKind
+from app.auth.providers.password_session_provider import PasswordSessionProvider
+from app.auth.session.session_cookie import SessionCookie
+from app.auth.session.session_service import SessionService
+from app.auth.users.user_repository import UserRepository
+from app.auth.users.user_status import UserStatus
+from app.database.database_manager import DatabaseManager
+from app.models.types.ulid_id import new_ulid
+
+
+def _request(conn: duckdb.DuckDBPyConnection | None, cookie: str | None) -> Request:
+    """Build a request whose ``app.state.db_connection`` is ``conn``.
+
+    Args:
+        conn: The connection to expose on ``app.state`` (or ``None``).
+        cookie: The raw ``lavs_session`` cookie value, or ``None`` for no cookie.
+
+    Returns:
+        A request carrying the given cookie and application state.
+    """
+    headers: list[tuple[bytes, bytes]] = []
+    if cookie is not None:
+        headers.append((b"cookie", f"{SessionCookie.NAME}={cookie}".encode()))
+    app = SimpleNamespace(state=SimpleNamespace(db_connection=conn))
+    scope = {"type": "http", "method": "GET", "path": "/", "headers": headers, "app": app}
+    return Request(scope)
+
+
+class TestPasswordSessionProvider(IsolatedAsyncioTestCase):
+    """Cookie-based session authentication."""
+
+    def setUp(self) -> None:
+        """Open an in-memory DuckDB, install the schema, and seed a user."""
+        self._conn = duckdb.connect(":memory:")
+        DatabaseManager.create_tables_on(self._conn)
+        self._sessions = SessionService()
+        self._provider = PasswordSessionProvider(edition="oss")
+        self._user_id = new_ulid()
+
+    def tearDown(self) -> None:
+        """Close the in-memory connection."""
+        self._conn.close()
+
+    async def _seed_user(self) -> None:
+        await UserRepository().create_user(
+            self._conn,
+            user_id=self._user_id,
+            email="engineer@example.com",
+            password_hash="$argon2id$fake",
+            status=UserStatus.ACTIVE,
+            edition="oss",
+        )
+
+    async def test_valid_cookie_returns_user_principal(self) -> None:
+        """A cookie naming a live session resolves to a user principal."""
+        # Arrange
+        await self._seed_user()
+        token = self._sessions.create_session(self._conn, user_id=self._user_id, ttl_seconds=3600)
+        request = _request(self._conn, token)
+
+        # Act
+        principal = await self._provider.authenticate(request)
+
+        # Assert
+        assert principal is not None
+        assert principal.kind is PrincipalKind.USER
+        assert principal.id == self._user_id
+        assert principal.email == "engineer@example.com"
+        assert principal.edition == "oss"
+
+    async def test_missing_cookie_returns_none(self) -> None:
+        """No session cookie means the provider declines the request."""
+        # Arrange
+        request = _request(self._conn, None)
+
+        # Act / Assert
+        assert await self._provider.authenticate(request) is None
+
+    async def test_unknown_token_returns_none(self) -> None:
+        """A cookie with no matching session resolves to None."""
+        # Arrange
+        request = _request(self._conn, "not-a-real-token")
+
+        # Act / Assert
+        assert await self._provider.authenticate(request) is None
+
+    async def test_expired_session_returns_none(self) -> None:
+        """An expired session cookie authenticates nobody."""
+        # Arrange
+        await self._seed_user()
+        token = self._sessions.create_session(self._conn, user_id=self._user_id, ttl_seconds=-1)
+        request = _request(self._conn, token)
+
+        # Act / Assert
+        assert await self._provider.authenticate(request) is None
+
+    async def test_no_database_connection_returns_none(self) -> None:
+        """With no live connection the provider declines rather than raises."""
+        # Arrange
+        request = _request(None, "any-token")
+
+        # Act / Assert
+        assert await self._provider.authenticate(request) is None

--- a/tests/unit/auth/session/__init__.py
+++ b/tests/unit/auth/session/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the R2 session store."""

--- a/tests/unit/auth/session/test_session_service.py
+++ b/tests/unit/auth/session/test_session_service.py
@@ -1,0 +1,120 @@
+"""Unit tests for :class:`SessionService` against an in-memory database."""
+
+from unittest import IsolatedAsyncioTestCase
+
+import duckdb
+
+from app.auth.session.session_service import SessionService
+from app.auth.token_service import TokenService
+from app.auth.users.user_repository import UserRepository
+from app.auth.users.user_status import UserStatus
+from app.database.database_manager import DatabaseManager
+from app.models.types.ulid_id import new_ulid
+
+
+class TestSessionService(IsolatedAsyncioTestCase):
+    """Create, look up, and revoke session tokens."""
+
+    def setUp(self) -> None:
+        """Open an in-memory DuckDB, install the schema, and seed a user."""
+        self._conn = duckdb.connect(":memory:")
+        DatabaseManager.create_tables_on(self._conn)
+        self._service = SessionService()
+        self._tokens = TokenService()
+        self._user_id = new_ulid()
+
+    def tearDown(self) -> None:
+        """Close the in-memory connection."""
+        self._conn.close()
+
+    async def _seed_user(self) -> None:
+        await UserRepository().create_user(
+            self._conn,
+            user_id=self._user_id,
+            email="engineer@example.com",
+            password_hash="$argon2id$fake",
+            status=UserStatus.ACTIVE,
+            edition="oss",
+        )
+
+    async def test_create_session_stores_hashed_token_not_raw(self) -> None:
+        """The stored row carries the token's hash, never the raw token."""
+        # Arrange
+        await self._seed_user()
+
+        # Act
+        token = self._service.create_session(self._conn, user_id=self._user_id, ttl_seconds=3600)
+
+        # Assert
+        row = self._conn.execute(
+            "SELECT user_id, token_hash FROM sessions WHERE user_id = ?", [self._user_id]
+        ).fetchone()
+        assert row is not None
+        assert row[0] == self._user_id
+        assert row[1] == self._tokens.hash_token(token)
+        assert row[1] != token
+
+    async def test_create_session_sets_future_expiry(self) -> None:
+        """A positive TTL produces an ``expires_at`` in the future."""
+        # Arrange
+        await self._seed_user()
+
+        # Act
+        self._service.create_session(self._conn, user_id=self._user_id, ttl_seconds=3600)
+
+        # Assert
+        row = self._conn.execute(
+            "SELECT expires_at > CURRENT_TIMESTAMP FROM sessions WHERE user_id = ?",
+            [self._user_id],
+        ).fetchone()
+        assert row is not None
+        assert row[0] is True
+
+    async def test_lookup_active_returns_user_id(self) -> None:
+        """A live session resolves to its owning user id."""
+        # Arrange
+        await self._seed_user()
+        token = self._service.create_session(self._conn, user_id=self._user_id, ttl_seconds=3600)
+
+        # Act
+        result = self._service.lookup_active_user_id(self._conn, token)
+
+        # Assert
+        assert result == self._user_id
+
+    async def test_lookup_unknown_token_returns_none(self) -> None:
+        """A token with no session row resolves to None."""
+        # Act
+        result = self._service.lookup_active_user_id(self._conn, "no-such-token")
+
+        # Assert
+        assert result is None
+
+    async def test_lookup_expired_session_returns_none(self) -> None:
+        """A session whose expiry has passed no longer authenticates."""
+        # Arrange
+        await self._seed_user()
+        token = self._service.create_session(self._conn, user_id=self._user_id, ttl_seconds=-1)
+
+        # Act
+        result = self._service.lookup_active_user_id(self._conn, token)
+
+        # Assert
+        assert result is None
+
+    async def test_delete_session_revokes_lookup(self) -> None:
+        """Deleting a session makes its token stop resolving."""
+        # Arrange
+        await self._seed_user()
+        token = self._service.create_session(self._conn, user_id=self._user_id, ttl_seconds=3600)
+
+        # Act
+        self._service.delete_session(self._conn, token)
+
+        # Assert
+        assert self._service.lookup_active_user_id(self._conn, token) is None
+
+    async def test_delete_unknown_token_is_noop(self) -> None:
+        """Deleting a non-existent session raises nothing (idempotent)."""
+        # Act / Assert
+        self._service.delete_session(self._conn, "no-such-token")

--- a/tests/unit/auth/signup/__init__.py
+++ b/tests/unit/auth/signup/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the R1 sign-up / email-verification lane."""

--- a/tests/unit/auth/signup/test_signup_model.py
+++ b/tests/unit/auth/signup/test_signup_model.py
@@ -1,0 +1,46 @@
+"""Unit tests for :class:`SignupModel` input validation and normalisation."""
+
+from unittest import TestCase
+
+from pydantic import ValidationError
+
+from app.auth.signup.signup_policy import SignupPolicy
+from app.models.requests.signup_model import SignupModel
+
+
+class TestSignupModel(TestCase):
+    """Email normalisation and password-strength validation."""
+
+    def _valid_password(self) -> str:
+        return "a" * SignupPolicy.MIN_PASSWORD_LENGTH
+
+    def test_email_is_lowercased_and_trimmed(self) -> None:
+        """A mixed-case, padded email is normalised to lower-case and trimmed."""
+        # Arrange / Act
+        model = SignupModel(email="  Engineer@Example.COM  ", password=self._valid_password())
+
+        # Assert
+        assert model.email == "engineer@example.com"
+
+    def test_malformed_email_is_rejected(self) -> None:
+        """An address without a domain fails validation."""
+        # Act / Assert
+        with self.assertRaises(ValidationError):
+            SignupModel(email="not-an-email", password=self._valid_password())
+
+    def test_short_password_is_rejected(self) -> None:
+        """A password below the policy minimum fails validation."""
+        # Arrange
+        short = "a" * (SignupPolicy.MIN_PASSWORD_LENGTH - 1)
+
+        # Act / Assert
+        with self.assertRaises(ValidationError):
+            SignupModel(email="engineer@example.com", password=short)
+
+    def test_minimum_length_password_is_accepted(self) -> None:
+        """A password exactly at the minimum length is accepted."""
+        # Act
+        model = SignupModel(email="engineer@example.com", password=self._valid_password())
+
+        # Assert
+        assert len(model.password) == SignupPolicy.MIN_PASSWORD_LENGTH

--- a/tests/unit/auth/signup/test_signup_service.py
+++ b/tests/unit/auth/signup/test_signup_service.py
@@ -1,0 +1,142 @@
+"""Unit tests for :class:`SignupService` against an in-memory database."""
+
+from unittest import IsolatedAsyncioTestCase
+
+import duckdb
+
+from app.auth.auth_settings import AuthSettings
+from app.auth.password_hasher import PasswordHasher
+from app.auth.signup.signup_service import SignupService
+from app.auth.signup.verification_settings import VerificationSettings
+from app.auth.token_service import TokenService
+from app.auth.users.user_repository import UserRepository
+from app.auth.users.user_status import UserStatus
+from app.database.database_manager import DatabaseManager
+from app.errors.conflict_error import ConflictError
+from app.errors.domain_not_allowed_error import DomainNotAllowedError
+from app.mail.capture_mailer import CaptureMailer
+from app.models.requests.signup_model import SignupModel
+
+
+class TestSignupService(IsolatedAsyncioTestCase):
+    """Domain allow-list, duplicate handling, password + token hashing."""
+
+    _PASSWORD: str = "correct horse battery staple"
+
+    def setUp(self) -> None:
+        """Open an in-memory DuckDB and install the real schema."""
+        self._conn = duckdb.connect(":memory:")
+        DatabaseManager.create_tables_on(self._conn)
+        self._mailer = CaptureMailer()
+        self._service = SignupService(verification_settings=VerificationSettings(ttl_seconds=3600))
+
+    def tearDown(self) -> None:
+        """Close the in-memory connection."""
+        self._conn.close()
+
+    def _body(self, email: str = "engineer@example.com") -> SignupModel:
+        return SignupModel(email=email, password=self._PASSWORD)
+
+    async def _register(self, settings: AuthSettings, email: str = "engineer@example.com") -> None:
+        await self._service.register(
+            conn=self._conn, mailer=self._mailer, model=self._body(email), settings=settings
+        )
+
+    async def test_open_allow_list_accepts_any_domain(self) -> None:
+        """An empty allow-list permits sign-up from any domain."""
+        # Arrange
+        settings = AuthSettings(allowed_email_domains=())
+
+        # Act
+        await self._register(settings)
+
+        # Assert
+        row = await UserRepository().get_user_by_email(self._conn, "engineer@example.com")
+        assert row is not None
+
+    async def test_allowed_domain_is_accepted(self) -> None:
+        """A domain present on the allow-list is accepted."""
+        # Arrange
+        settings = AuthSettings(allowed_email_domains=("example.com",))
+
+        # Act
+        await self._register(settings)
+
+        # Assert
+        assert self._mailer.last_for("engineer@example.com") is not None
+
+    async def test_disallowed_domain_is_rejected(self) -> None:
+        """A domain absent from a non-empty allow-list raises 403 and stores nothing."""
+        # Arrange
+        settings = AuthSettings(allowed_email_domains=("allowed.com",))
+
+        # Act / Assert
+        with self.assertRaises(DomainNotAllowedError):
+            await self._register(settings, email="engineer@example.com")
+        assert await UserRepository().get_user_by_email(self._conn, "engineer@example.com") is None
+        assert self._mailer.messages() == ()
+
+    async def test_duplicate_email_raises_conflict(self) -> None:
+        """A second sign-up for the same email raises a conflict."""
+        # Arrange
+        settings = AuthSettings(allowed_email_domains=())
+        await self._register(settings)
+
+        # Act / Assert
+        with self.assertRaises(ConflictError):
+            await self._register(settings)
+
+    async def test_password_is_stored_hashed(self) -> None:
+        """The stored password differs from plaintext yet verifies."""
+        # Arrange
+        settings = AuthSettings(allowed_email_domains=())
+
+        # Act
+        await self._register(settings)
+
+        # Assert
+        row = await UserRepository().get_user_by_email(self._conn, "engineer@example.com")
+        assert row is not None
+        stored_hash = str(row[2])
+        assert stored_hash != self._PASSWORD
+        assert PasswordHasher().verify_password(stored_hash, self._PASSWORD) is True
+
+    async def test_user_created_pending(self) -> None:
+        """A newly signed-up user starts in the pending status."""
+        # Arrange
+        settings = AuthSettings(allowed_email_domains=())
+
+        # Act
+        await self._register(settings)
+
+        # Assert
+        row = await UserRepository().get_user_by_email(self._conn, "engineer@example.com")
+        assert row is not None
+        assert row[3] == UserStatus.PENDING.value
+
+    async def test_verification_token_stored_hashed_not_raw(self) -> None:
+        """The token in the email is raw; the DB only holds its SHA-256 hash."""
+        # Arrange
+        settings = AuthSettings(allowed_email_domains=())
+
+        # Act
+        await self._register(settings)
+
+        # Assert
+        message = self._mailer.last_for("engineer@example.com")
+        assert message is not None
+        raw_token = self._extract_token(message.body)
+        stored = self._conn.execute("SELECT token_hash FROM email_verification_tokens").fetchall()
+        stored_hashes = {row[0] for row in stored}
+        assert raw_token not in stored_hashes
+        assert TokenService().hash_token(raw_token) in stored_hashes
+
+    @staticmethod
+    def _extract_token(body: str) -> str:
+        """Pull the raw token line out of the verification email body.
+
+        The token is the only non-empty line in the template that contains no
+        whitespace; every prose line does.
+        """
+        lines = [line.strip() for line in body.splitlines() if line.strip()]
+        return next(line for line in lines if " " not in line)

--- a/tests/unit/auth/signup/test_verification_service.py
+++ b/tests/unit/auth/signup/test_verification_service.py
@@ -1,0 +1,95 @@
+"""Unit tests for :class:`VerificationService` against an in-memory database."""
+
+from unittest import IsolatedAsyncioTestCase
+
+import duckdb
+
+from app.auth.signup.verification_service import VerificationService
+from app.auth.signup.verification_token_repository import VerificationTokenRepository
+from app.auth.token_service import TokenService
+from app.auth.users.user_repository import UserRepository
+from app.auth.users.user_status import UserStatus
+from app.database.database_manager import DatabaseManager
+from app.errors.not_found_error import NotFoundError
+from app.models.requests.verify_model import VerifyModel
+from app.models.responses.user_response_model import UserResponseModel
+from app.models.types.ulid_id import new_ulid
+
+
+class TestVerificationService(IsolatedAsyncioTestCase):
+    """Activation, single-use consumption, and generic failure on a bad token."""
+
+    def setUp(self) -> None:
+        """Open an in-memory DuckDB, install schema, seed a pending user + token."""
+        self._conn = duckdb.connect(":memory:")
+        DatabaseManager.create_tables_on(self._conn)
+        self._tokens = VerificationTokenRepository()
+        self._token_service = TokenService()
+        self._service = VerificationService()
+        self._user_id = new_ulid()
+        self._raw_token = self._token_service.generate_token()
+
+    def tearDown(self) -> None:
+        """Close the in-memory connection."""
+        self._conn.close()
+
+    async def _seed(self, ttl_seconds: int = 3600) -> None:
+        await UserRepository().create_user(
+            self._conn,
+            user_id=self._user_id,
+            email="engineer@example.com",
+            password_hash="$argon2id$fake",
+            status=UserStatus.PENDING,
+            edition="oss",
+        )
+        await self._tokens.issue(
+            self._conn,
+            token_hash=self._token_service.hash_token(self._raw_token),
+            user_id=self._user_id,
+            ttl_seconds=ttl_seconds,
+        )
+
+    async def test_verify_activates_user_and_returns_model(self) -> None:
+        """A valid token activates the user and returns the safe model."""
+        # Arrange
+        await self._seed()
+
+        # Act
+        result = await self._service.verify(self._conn, VerifyModel(token=self._raw_token))
+
+        # Assert
+        assert isinstance(result, UserResponseModel)
+        assert result.id == self._user_id
+        assert result.status == UserStatus.ACTIVE.value
+        assert "password_hash" not in result.model_dump()
+
+    async def test_verify_is_single_use(self) -> None:
+        """A second verification of the same token fails generically."""
+        # Arrange
+        await self._seed()
+        await self._service.verify(self._conn, VerifyModel(token=self._raw_token))
+
+        # Act / Assert
+        with self.assertRaises(NotFoundError):
+            await self._service.verify(self._conn, VerifyModel(token=self._raw_token))
+
+    async def test_expired_token_fails(self) -> None:
+        """An expired token cannot verify and leaves the user pending."""
+        # Arrange
+        await self._seed(ttl_seconds=-10)
+
+        # Act / Assert
+        with self.assertRaises(NotFoundError):
+            await self._service.verify(self._conn, VerifyModel(token=self._raw_token))
+        row = await UserRepository().get_user_by_id(self._conn, self._user_id)
+        assert row is not None
+        assert row[3] == UserStatus.PENDING.value
+
+    async def test_unknown_token_fails(self) -> None:
+        """A token that was never issued fails generically."""
+        # Arrange
+        await self._seed()
+
+        # Act / Assert
+        with self.assertRaises(NotFoundError):
+            await self._service.verify(self._conn, VerifyModel(token="never-issued-token"))

--- a/tests/unit/auth/signup/test_verification_token_repository.py
+++ b/tests/unit/auth/signup/test_verification_token_repository.py
@@ -1,0 +1,78 @@
+"""Unit tests for :class:`VerificationTokenRepository` over an in-memory DB."""
+
+from unittest import IsolatedAsyncioTestCase
+
+import duckdb
+
+from app.auth.signup.verification_token_repository import VerificationTokenRepository
+from app.auth.users.user_repository import UserRepository
+from app.auth.users.user_status import UserStatus
+from app.database.database_manager import DatabaseManager
+from app.models.types.ulid_id import new_ulid
+
+
+class TestVerificationTokenRepository(IsolatedAsyncioTestCase):
+    """Issue, find (active only), and consume verification tokens."""
+
+    def setUp(self) -> None:
+        """Open an in-memory DuckDB, install the schema, seed a user."""
+        self._conn = duckdb.connect(":memory:")
+        DatabaseManager.create_tables_on(self._conn)
+        self._repo = VerificationTokenRepository()
+        self._user_id = new_ulid()
+
+    def tearDown(self) -> None:
+        """Close the in-memory connection."""
+        self._conn.close()
+
+    async def _seed_user(self) -> None:
+        await UserRepository().create_user(
+            self._conn,
+            user_id=self._user_id,
+            email="engineer@example.com",
+            password_hash="$argon2id$fake",
+            status=UserStatus.PENDING,
+            edition="oss",
+        )
+
+    async def test_issue_then_find_active_returns_row(self) -> None:
+        """A freshly issued, unexpired token is found active."""
+        # Arrange
+        await self._seed_user()
+        await self._repo.issue(self._conn, "hash-a", self._user_id, ttl_seconds=3600)
+
+        # Act
+        row = await self._repo.find_active(self._conn, "hash-a")
+
+        # Assert
+        assert row is not None
+        assert row[1] == self._user_id
+
+    async def test_expired_token_is_not_active(self) -> None:
+        """A token issued with a negative TTL is already expired."""
+        # Arrange
+        await self._seed_user()
+        await self._repo.issue(self._conn, "hash-expired", self._user_id, ttl_seconds=-10)
+
+        # Act
+        row = await self._repo.find_active(self._conn, "hash-expired")
+
+        # Assert
+        assert row is None
+
+    async def test_consumed_token_is_not_active(self) -> None:
+        """Consuming a token removes it from the active set (single-use)."""
+        # Arrange
+        await self._seed_user()
+        await self._repo.issue(self._conn, "hash-b", self._user_id, ttl_seconds=3600)
+
+        # Act
+        await self._repo.consume(self._conn, "hash-b")
+
+        # Assert
+        assert await self._repo.find_active(self._conn, "hash-b") is None
+
+    async def test_unknown_hash_is_not_active(self) -> None:
+        """A hash that was never issued is never active."""
+        # Act / Assert
+        assert await self._repo.find_active(self._conn, "never-issued") is None

--- a/tests/unit/auth/test_auth_registry.py
+++ b/tests/unit/auth/test_auth_registry.py
@@ -1,0 +1,42 @@
+"""Unit tests for :class:`AuthRegistry`."""
+
+from fastapi import Request
+
+from app.auth.auth_provider import AuthProvider
+from app.auth.auth_registry import AuthRegistry
+from app.auth.principal import Principal
+
+
+class _StubProvider(AuthProvider):
+    """A provider that never authenticates (identity is irrelevant here)."""
+
+    async def authenticate(self, request: Request) -> Principal | None:
+        return None
+
+
+class TestAuthRegistry:
+    """Registration order and emptiness."""
+
+    def test_new_registry_is_empty(self) -> None:
+        """A fresh registry reports empty and yields no providers."""
+        # Arrange
+        registry = AuthRegistry()
+
+        # Act / Assert
+        assert registry.is_empty() is True
+        assert registry.providers() == ()
+
+    def test_preserves_registration_order(self) -> None:
+        """Providers are returned in the order they were registered."""
+        # Arrange
+        registry = AuthRegistry()
+        first = _StubProvider()
+        second = _StubProvider()
+
+        # Act
+        registry.register(first)
+        registry.register(second)
+
+        # Assert
+        assert registry.is_empty() is False
+        assert registry.providers() == (first, second)

--- a/tests/unit/auth/test_auth_resolver.py
+++ b/tests/unit/auth/test_auth_resolver.py
@@ -1,0 +1,100 @@
+"""Unit tests for :class:`AuthResolver` resolution semantics."""
+
+from unittest import IsolatedAsyncioTestCase
+
+from fastapi import Request
+
+from app.auth.auth_registry import AuthRegistry
+from app.auth.auth_resolver import AuthResolver
+from app.auth.principal import Principal
+from app.auth.principal_kind import PrincipalKind
+from app.auth.service_identity import ServiceIdentity
+from app.errors.unauthorized_error import UnauthorizedError
+
+
+def _make_request() -> Request:
+    """Build a minimal ASGI request (no header/app access is exercised here)."""
+    scope = {"type": "http", "method": "GET", "path": "/", "headers": []}
+    return Request(scope)
+
+
+class _MatchingProvider:
+    """A provider that always returns a fixed principal."""
+
+    def __init__(self, principal: Principal) -> None:
+        self._principal = principal
+
+    async def authenticate(self, request: Request) -> Principal | None:
+        return self._principal
+
+
+class _NonMatchingProvider:
+    """A provider that never authenticates."""
+
+    async def authenticate(self, request: Request) -> Principal | None:
+        return None
+
+
+class TestAuthResolver(IsolatedAsyncioTestCase):
+    """The single-principal-per-request resolution rules."""
+
+    async def test_unconfigured_returns_anonymous(self) -> None:
+        """No providers and auth not configured yields the anonymous principal."""
+        # Arrange
+        resolver = AuthResolver(AuthRegistry(), edition="oss", auth_configured=False)
+
+        # Act
+        principal = await resolver.resolve(_make_request())
+
+        # Assert
+        assert principal.kind is PrincipalKind.SERVICE
+        assert principal.id == ServiceIdentity.ANONYMOUS.value
+        assert principal.edition == "oss"
+
+    async def test_configured_without_match_raises_401(self) -> None:
+        """Auth configured but no provider matching raises Unauthorized."""
+        # Arrange
+        resolver = AuthResolver(AuthRegistry(), edition="oss", auth_configured=True)
+
+        # Act / Assert
+        with self.assertRaises(UnauthorizedError):
+            await resolver.resolve(_make_request())
+
+    async def test_first_matching_provider_wins(self) -> None:
+        """The first provider to return a principal short-circuits resolution."""
+        # Arrange
+        expected = Principal(kind=PrincipalKind.USER, id="u1", edition="oss")
+        registry = AuthRegistry()
+        registry.register(_MatchingProvider(expected))
+        resolver = AuthResolver(registry, edition="oss", auth_configured=True)
+
+        # Act
+        principal = await resolver.resolve(_make_request())
+
+        # Assert
+        assert principal is expected
+
+    async def test_enabled_provider_that_declines_raises_401(self) -> None:
+        """A registered provider that returns None still fails closed."""
+        # Arrange
+        registry = AuthRegistry()
+        registry.register(_NonMatchingProvider())
+        resolver = AuthResolver(registry, edition="oss", auth_configured=False)
+
+        # Act / Assert
+        with self.assertRaises(UnauthorizedError):
+            await resolver.resolve(_make_request())
+
+    async def test_registry_is_read_live(self) -> None:
+        """A provider registered after construction is honoured on resolve."""
+        # Arrange
+        registry = AuthRegistry()
+        resolver = AuthResolver(registry, edition="oss", auth_configured=True)
+        expected = Principal(kind=PrincipalKind.USER, id="late", edition="oss")
+
+        # Act — register only after the resolver already exists
+        registry.register(_MatchingProvider(expected))
+        principal = await resolver.resolve(_make_request())
+
+        # Assert
+        assert principal is expected

--- a/tests/unit/auth/test_auth_settings.py
+++ b/tests/unit/auth/test_auth_settings.py
@@ -1,0 +1,112 @@
+"""Unit tests for :class:`AuthSettings` environment parsing and injection."""
+
+import pytest
+
+from app.auth.auth_mode import AuthMode
+from app.auth.auth_settings import AuthSettings
+
+_MODES = "LAVS_AUTH_MODES"
+_DOMAINS = "LAVS_ALLOWED_EMAIL_DOMAINS"
+_TTL = "LAVS_SESSION_TTL_SECONDS"
+_EDITION = "LAVS_EDITION"
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure a clean environment for every case."""
+    for name in (_MODES, _DOMAINS, _TTL, _EDITION):
+        monkeypatch.delenv(name, raising=False)
+
+
+class TestModes:
+    """``LAVS_AUTH_MODES`` parsing."""
+
+    def test_empty_env_yields_no_modes(self) -> None:
+        """No env value means no modes are enabled."""
+        # Act / Assert
+        assert AuthSettings().modes() == set()
+
+    def test_parses_comma_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A comma list is parsed into the AuthMode set (case/space tolerant)."""
+        # Arrange
+        monkeypatch.setenv(_MODES, " Password , apikey ")
+
+        # Act / Assert
+        assert AuthSettings().modes() == {AuthMode.PASSWORD, AuthMode.APIKEY}
+
+    def test_ignores_unknown_modes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Forward-compatible tokens (e.g. stytch) are ignored, not fatal."""
+        # Arrange
+        monkeypatch.setenv(_MODES, "password,stytch")
+
+        # Act / Assert
+        assert AuthSettings().modes() == {AuthMode.PASSWORD}
+
+    def test_injected_modes_override_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An explicit modes argument overrides the environment entirely."""
+        # Arrange
+        monkeypatch.setenv(_MODES, "apikey")
+
+        # Act / Assert
+        assert AuthSettings(modes={AuthMode.PASSWORD}).modes() == {AuthMode.PASSWORD}
+
+    def test_password_and_apikey_flags(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The convenience predicates reflect the parsed modes."""
+        # Arrange
+        monkeypatch.setenv(_MODES, "password")
+        settings = AuthSettings()
+
+        # Act / Assert
+        assert settings.password_enabled() is True
+        assert settings.apikey_mode_enabled() is False
+
+
+class TestAllowedEmailDomains:
+    """``LAVS_ALLOWED_EMAIL_DOMAINS`` parsing."""
+
+    def test_empty_means_allow_all(self) -> None:
+        """No env value yields an empty allow-list (allow all)."""
+        # Act / Assert
+        assert AuthSettings().allowed_email_domains() == ()
+
+    def test_lowercases_and_splits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Domains are trimmed, split, and lower-cased."""
+        # Arrange
+        monkeypatch.setenv(_DOMAINS, "Example.com, Acme.IO ")
+
+        # Act / Assert
+        assert AuthSettings().allowed_email_domains() == ("example.com", "acme.io")
+
+
+class TestSessionTtl:
+    """``LAVS_SESSION_TTL_SECONDS`` parsing."""
+
+    def test_default_is_one_week(self) -> None:
+        """The default TTL is 604800 seconds (7 days)."""
+        # Act / Assert
+        assert AuthSettings().session_ttl_seconds() == 604800
+
+    def test_parses_env_integer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A numeric env value overrides the default."""
+        # Arrange
+        monkeypatch.setenv(_TTL, "3600")
+
+        # Act / Assert
+        assert AuthSettings().session_ttl_seconds() == 3600
+
+
+class TestEdition:
+    """``LAVS_EDITION`` parsing."""
+
+    def test_default_is_oss(self) -> None:
+        """The default edition is ``oss``."""
+        # Act / Assert
+        assert AuthSettings().edition() == "oss"
+
+    def test_reads_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An env value overrides the default edition."""
+        # Arrange
+        monkeypatch.setenv(_EDITION, "ee")
+
+        # Act / Assert
+        assert AuthSettings().edition() == "ee"

--- a/tests/unit/auth/test_password_hasher.py
+++ b/tests/unit/auth/test_password_hasher.py
@@ -1,0 +1,51 @@
+"""Unit tests for :class:`PasswordHasher` (argon2id)."""
+
+from app.auth.password_hasher import PasswordHasher
+
+
+class TestPasswordHasher:
+    """Hashing never leaks plaintext; verification is correct."""
+
+    def test_hash_is_not_plaintext(self) -> None:
+        """The hash must not be (or contain) the plaintext password."""
+        # Arrange
+        hasher = PasswordHasher()
+        password = "correct horse battery staple"
+
+        # Act
+        digest = hasher.hash_password(password)
+
+        # Assert
+        assert digest != password
+        assert password not in digest
+        assert digest.startswith("$argon2id$")
+
+    def test_verify_accepts_correct_password(self) -> None:
+        """A matching password verifies true."""
+        # Arrange
+        hasher = PasswordHasher()
+        digest = hasher.hash_password("s3cret-pass")
+
+        # Act / Assert
+        assert hasher.verify_password(digest, "s3cret-pass") is True
+
+    def test_verify_rejects_wrong_password(self) -> None:
+        """A wrong password verifies false (no exception surfaces)."""
+        # Arrange
+        hasher = PasswordHasher()
+        digest = hasher.hash_password("s3cret-pass")
+
+        # Act / Assert
+        assert hasher.verify_password(digest, "wrong-pass") is False
+
+    def test_hashes_are_salted(self) -> None:
+        """Hashing the same password twice yields different digests (salt)."""
+        # Arrange
+        hasher = PasswordHasher()
+
+        # Act
+        first = hasher.hash_password("same")
+        second = hasher.hash_password("same")
+
+        # Assert
+        assert first != second

--- a/tests/unit/auth/test_principal.py
+++ b/tests/unit/auth/test_principal.py
@@ -1,0 +1,29 @@
+"""Unit tests for :class:`Principal`."""
+
+from app.auth.principal import Principal
+from app.auth.principal_kind import PrincipalKind
+
+
+class TestPrincipal:
+    """The resolved-caller model."""
+
+    def test_user_principal_carries_all_fields(self) -> None:
+        """A user principal round-trips kind, id, email, and edition."""
+        # Arrange / Act
+        principal = Principal(
+            kind=PrincipalKind.USER, id="u1", email="engineer@example.com", edition="oss"
+        )
+
+        # Assert
+        assert principal.kind is PrincipalKind.USER
+        assert principal.id == "u1"
+        assert principal.email == "engineer@example.com"
+        assert principal.edition == "oss"
+
+    def test_email_is_optional(self) -> None:
+        """A service principal may omit the email."""
+        # Act
+        principal = Principal(kind=PrincipalKind.SERVICE, id="anonymous", edition="oss")
+
+        # Assert
+        assert principal.email is None

--- a/tests/unit/auth/test_require_principal.py
+++ b/tests/unit/auth/test_require_principal.py
@@ -1,0 +1,66 @@
+"""Unit tests for the ``require_principal`` FastAPI dependency.
+
+Exercised through a tiny app so the real request/``app.state`` plumbing is used:
+one route echoes the resolved principal. Proves the two contract-critical paths
+— open when nothing is configured (the backward-compat default), and fail-closed
+(401) when a configured resolver is present on ``app.state``.
+"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.auth.auth_mode import AuthMode
+from app.auth.auth_resolver_factory import AuthResolverFactory
+from app.auth.auth_settings import AuthSettings
+from app.auth.require_principal import PrincipalDep
+from app.errors.handlers import register_error_handlers
+
+
+def _build_app() -> FastAPI:
+    """Build a minimal app with one principal-protected route."""
+    app = FastAPI()
+    register_error_handlers(app)
+
+    @app.get("/whoami")
+    async def whoami(principal: PrincipalDep) -> dict[str, str]:
+        return {"kind": principal.kind.value, "id": principal.id}
+
+    return app
+
+
+class TestRequirePrincipalOpen:
+    """With no resolver configured, requests resolve to the anonymous principal."""
+
+    def test_open_when_unconfigured(self, monkeypatch) -> None:
+        """A bare app (no lifespan, no env) stays open via the fallback resolver."""
+        # Arrange
+        monkeypatch.delenv("LAVS_AUTH_MODES", raising=False)
+        monkeypatch.delenv("LAVS_API_KEY", raising=False)
+        client = TestClient(_build_app())
+
+        # Act
+        response = client.get("/whoami")
+
+        # Assert
+        assert response.status_code == 200
+        assert response.json() == {"kind": "service", "id": "anonymous"}
+
+
+class TestRequirePrincipalFailClosed:
+    """With a configured resolver on app.state, unauthenticated requests 401."""
+
+    def test_fail_closed_when_configured(self, monkeypatch) -> None:
+        """A password-configured resolver rejects a credential-less request."""
+        # Arrange
+        monkeypatch.delenv("LAVS_API_KEY", raising=False)
+        app = _build_app()
+        settings = AuthSettings(modes={AuthMode.PASSWORD})
+        app.state.auth_resolver = AuthResolverFactory.build_resolver(settings)
+        client = TestClient(app)
+
+        # Act
+        response = client.get("/whoami")
+
+        # Assert
+        assert response.status_code == 401
+        assert response.json()["error"]["code"] == "unauthorized"

--- a/tests/unit/auth/test_token_service.py
+++ b/tests/unit/auth/test_token_service.py
@@ -1,0 +1,45 @@
+"""Unit tests for :class:`TokenService`."""
+
+from app.auth.token_service import TokenService
+
+
+class TestTokenService:
+    """Token generation, hashing, and constant-time comparison."""
+
+    def test_generated_tokens_are_unique(self) -> None:
+        """Successive tokens are high-entropy and distinct."""
+        # Arrange
+        service = TokenService()
+
+        # Act
+        first = service.generate_token()
+        second = service.generate_token()
+
+        # Assert
+        assert first != second
+        assert len(first) > 0
+
+    def test_hash_is_deterministic_and_not_the_token(self) -> None:
+        """The stored hash is the SHA-256 hex digest, never the raw token."""
+        # Arrange
+        service = TokenService()
+        token = service.generate_token()
+
+        # Act
+        digest = service.hash_token(token)
+
+        # Assert
+        assert digest == service.hash_token(token)
+        assert digest != token
+        assert len(digest) == 64
+
+    def test_compare_matches_only_the_right_token(self) -> None:
+        """``compare`` is true for the token behind a hash, false otherwise."""
+        # Arrange
+        service = TokenService()
+        token = service.generate_token()
+        digest = service.hash_token(token)
+
+        # Act / Assert
+        assert service.compare(token, digest) is True
+        assert service.compare("not-the-token", digest) is False

--- a/tests/unit/auth/users/__init__.py
+++ b/tests/unit/auth/users/__init__.py
@@ -1,0 +1,1 @@
+"""tests/unit/auth/users tests."""

--- a/tests/unit/auth/users/test_user_repository.py
+++ b/tests/unit/auth/users/test_user_repository.py
@@ -1,0 +1,98 @@
+"""Unit tests for :class:`UserRepository` against an in-memory database."""
+
+from unittest import IsolatedAsyncioTestCase
+
+import duckdb
+
+from app.auth.users.user_repository import UserRepository
+from app.auth.users.user_status import UserStatus
+from app.database.database_manager import DatabaseManager
+from app.models.responses.user_response_model import UserResponseModel
+from app.models.types.ulid_id import new_ulid
+
+
+class TestUserRepository(IsolatedAsyncioTestCase):
+    """Create, read, and activate users."""
+
+    def setUp(self) -> None:
+        """Open an in-memory DuckDB and install the real schema."""
+        self._conn = duckdb.connect(":memory:")
+        DatabaseManager.create_tables_on(self._conn)
+        self._repo = UserRepository()
+
+    def tearDown(self) -> None:
+        """Close the in-memory connection."""
+        self._conn.close()
+
+    async def _create(self, email: str) -> UserResponseModel:
+        return await self._repo.create_user(
+            self._conn,
+            user_id=new_ulid(),
+            email=email,
+            password_hash="$argon2id$fake",
+            status=UserStatus.PENDING,
+            edition="oss",
+        )
+
+    async def test_create_user_returns_safe_model(self) -> None:
+        """Creation returns a response model that never carries the hash."""
+        # Act
+        result = await self._create("engineer@example.com")
+
+        # Assert
+        assert isinstance(result, UserResponseModel)
+        assert result.email == "engineer@example.com"
+        assert result.status == UserStatus.PENDING.value
+        assert "password_hash" not in result.model_dump()
+
+    async def test_get_user_by_email_returns_row_with_hash(self) -> None:
+        """Lookup by email returns the raw row including the password hash."""
+        # Arrange
+        await self._create("lookup@example.com")
+
+        # Act
+        row = await self._repo.get_user_by_email(self._conn, "lookup@example.com")
+
+        # Assert
+        assert row is not None
+        assert row[1] == "lookup@example.com"
+        assert row[2] == "$argon2id$fake"
+
+    async def test_get_user_by_email_unknown_returns_none(self) -> None:
+        """An unknown email yields None."""
+        # Act / Assert
+        assert await self._repo.get_user_by_email(self._conn, "nobody@example.com") is None
+
+    async def test_get_user_by_id_round_trips(self) -> None:
+        """A created user is retrievable by its id."""
+        # Arrange
+        created = await self._create("byid@example.com")
+
+        # Act
+        row = await self._repo.get_user_by_id(self._conn, created.id)
+
+        # Assert
+        assert row is not None
+        assert row[0] == created.id
+
+    async def test_activate_user_sets_active_status(self) -> None:
+        """Activation transitions a pending user to active."""
+        # Arrange
+        created = await self._create("activate@example.com")
+
+        # Act
+        await self._repo.activate_user(self._conn, created.id)
+
+        # Assert
+        row = await self._repo.get_user_by_id(self._conn, created.id)
+        assert row is not None
+        assert row[3] == UserStatus.ACTIVE.value
+
+    async def test_duplicate_email_is_rejected(self) -> None:
+        """The UNIQUE(email) constraint rejects a second user with same email."""
+        # Arrange
+        await self._create("dupe@example.com")
+
+        # Act / Assert
+        with self.assertRaises(duckdb.ConstraintException):
+            await self._create("dupe@example.com")

--- a/tests/unit/mail/__init__.py
+++ b/tests/unit/mail/__init__.py
@@ -1,0 +1,1 @@
+"""tests/unit/mail tests."""

--- a/tests/unit/mail/test_capture_mailer.py
+++ b/tests/unit/mail/test_capture_mailer.py
@@ -1,0 +1,64 @@
+"""Unit tests for :class:`CaptureMailer`."""
+
+from app.mail.capture_mailer import CaptureMailer
+from app.mail.captured_email import CapturedEmail
+
+
+class TestCaptureMailer:
+    """In-memory capture of sent messages."""
+
+    def test_send_records_message(self) -> None:
+        """A sent message is captured with all fields."""
+        # Arrange
+        mailer = CaptureMailer()
+
+        # Act
+        mailer.send(to="user@example.com", subject="Verify", body="token=abc")
+
+        # Assert
+        assert mailer.messages() == (
+            CapturedEmail(to="user@example.com", subject="Verify", body="token=abc"),
+        )
+
+    def test_last_message_returns_most_recent(self) -> None:
+        """``last_message`` returns the newest capture, or None when empty."""
+        # Arrange
+        mailer = CaptureMailer()
+        assert mailer.last_message() is None
+
+        # Act
+        mailer.send(to="a@example.com", subject="One", body="1")
+        mailer.send(to="b@example.com", subject="Two", body="2")
+
+        # Assert
+        last = mailer.last_message()
+        assert last is not None
+        assert last.subject == "Two"
+
+    def test_last_for_filters_by_recipient(self) -> None:
+        """``last_for`` returns the newest message for a specific recipient."""
+        # Arrange
+        mailer = CaptureMailer()
+        mailer.send(to="a@example.com", subject="First", body="1")
+        mailer.send(to="b@example.com", subject="Other", body="2")
+        mailer.send(to="a@example.com", subject="Second", body="3")
+
+        # Act
+        result = mailer.last_for("a@example.com")
+
+        # Assert
+        assert result is not None
+        assert result.subject == "Second"
+        assert mailer.last_for("missing@example.com") is None
+
+    def test_clear_empties_the_buffer(self) -> None:
+        """``clear`` discards all captured messages."""
+        # Arrange
+        mailer = CaptureMailer()
+        mailer.send(to="a@example.com", subject="One", body="1")
+
+        # Act
+        mailer.clear()
+
+        # Assert
+        assert mailer.messages() == ()

--- a/tests/unit/models/test_user_response_model.py
+++ b/tests/unit/models/test_user_response_model.py
@@ -1,0 +1,34 @@
+"""Unit tests for :class:`UserResponseModel`."""
+
+from app.models.responses.user_response_model import UserResponseModel
+
+
+class TestUserResponseModel:
+    """The safe user projection."""
+
+    def test_carries_public_fields(self) -> None:
+        """The model exposes id, email, status, and edition."""
+        # Act
+        model = UserResponseModel(
+            id="01KW8WHA6STWW5N1VYRSHDTK1N",
+            email="engineer@example.com",
+            status="active",
+            edition="oss",
+        )
+
+        # Assert
+        dumped = model.model_dump()
+        assert dumped == {
+            "id": "01KW8WHA6STWW5N1VYRSHDTK1N",
+            "email": "engineer@example.com",
+            "status": "active",
+            "edition": "oss",
+        }
+
+    def test_never_exposes_password_hash(self) -> None:
+        """The response model has no password-hash field of any name."""
+        # Act
+        fields = set(UserResponseModel.model_fields)
+
+        # Assert
+        assert "password_hash" not in fields

--- a/tests/unit/routers/test_auth_wiring.py
+++ b/tests/unit/routers/test_auth_wiring.py
@@ -1,17 +1,28 @@
-"""Unit tests verifying API-key authentication is wired onto the data routers.
+"""Unit tests verifying principal authentication is wired onto the routers.
 
-The P1 resource routers (products, components, versions, timeline) are created
-as shells with the API-key dependency fixed at the router level; the resource
-lanes add the routes. These tests assert the auth contract structurally — that
-``get_api_key`` is present in each router's dependency list — so auth remains
-enforced no matter which routes the lanes subsequently add.
+P4 supersedes the bare API-key wiring: every resource router now fixes the
+``require_principal`` dependency at the router level (the resolver behind it
+decides open-when-unconfigured vs 401-when-configured). These tests assert the
+auth contract structurally — that ``require_principal`` is present in each
+router's dependency list, and that the public ``/meta`` and credential-
+establishing ``/auth`` routers deliberately do **not** carry it — so auth
+enforcement is independent of which routes the lanes subsequently add.
 """
 
 import pytest
 from fastapi import APIRouter
 
-from app.routers import components, products, timeline, versions
-from app.security.api_key import get_api_key
+from app.auth.require_principal import require_principal
+from app.routers import (
+    auth,
+    components,
+    events,
+    meta,
+    products,
+    releases,
+    timeline,
+    versions,
+)
 
 
 def _dependency_callables(router: APIRouter) -> list[object]:
@@ -28,24 +39,44 @@ def _dependency_callables(router: APIRouter) -> list[object]:
 
 @pytest.mark.parametrize(
     "router",
-    [products.router, components.router, versions.router, timeline.router],
+    [
+        products.router,
+        components.router,
+        versions.router,
+        timeline.router,
+        releases.router,
+        events.router,
+    ],
 )
-class TestAuthWiring:
-    """Each P1 resource router must enforce the API-key dependency."""
+class TestProtectedRouterWiring:
+    """Each resource router must enforce the principal dependency."""
 
-    def test_router_declares_api_key_dependency(self, router: APIRouter) -> None:
-        """The ``get_api_key`` dependency is present on the router."""
+    def test_router_declares_require_principal_dependency(self, router: APIRouter) -> None:
+        """The ``require_principal`` dependency is present on the router."""
         # Arrange
         dependencies = _dependency_callables(router)
 
         # Act / Assert
-        assert get_api_key in dependencies
+        assert require_principal in dependencies
 
-    def test_router_has_expected_prefix(self, router: APIRouter) -> None:
-        """The router is mounted under a non-empty resource prefix."""
+
+@pytest.mark.parametrize("router", [meta.router, auth.router])
+class TestPublicRouterWiring:
+    """Public / credential-establishing routers must NOT require a principal."""
+
+    def test_router_does_not_require_principal(self, router: APIRouter) -> None:
+        """Neither ``/meta`` nor the ``/auth`` shell carries the dependency."""
         # Arrange
-        prefix = router.prefix
+        dependencies = _dependency_callables(router)
 
         # Act / Assert
-        assert prefix.startswith("/")
-        assert len(prefix) > 1
+        assert require_principal not in dependencies
+
+
+class TestAuthRouterShell:
+    """The ``/auth`` router is a mounted, tagged shell for the auth lanes."""
+
+    def test_auth_router_has_prefix(self) -> None:
+        """The auth router is mounted under the ``/auth`` prefix."""
+        # Act / Assert
+        assert auth.router.prefix == "/auth"

--- a/uv.lock
+++ b/uv.lock
@@ -40,6 +40,49 @@ wheels = [
 ]
 
 [[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+]
+
+[[package]]
 name = "build"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -60,6 +103,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
 ]
 
 [[package]]
@@ -249,6 +351,7 @@ name = "lavs"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "argon2-cffi" },
     { name = "duckdb" },
     { name = "fastapi" },
     { name = "pydantic" },
@@ -270,6 +373,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "argon2-cffi", specifier = ">=25.1.0" },
     { name = "duckdb", specifier = ">=1.5.0" },
     { name = "fastapi", specifier = ">=0.135.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
@@ -339,6 +443,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## P4 — Auth (OSS) (Epic #18)

Real OSS auth per `API_CONTRACT.md §1–2`, built via the full 9-section governance flow (env-setup gate → foundation → 3 parallel worktree lanes + ATDD → aggregate → enforcement → **heavyweight security gate** → integration).

### What ships
- **Pluggable `AuthProvider`** abstraction + `require_principal` dependency (supersedes the bare API-key wiring on every resource route). **Fail-closed when a provider is configured, open when none** — so the existing suite stays green while real deployments enforce auth.
- **Password + sessions:** `POST /auth/signup` (email + domain allow-list, argon2id) → email verification (`POST /auth/verify`) → `POST /auth/login` (HttpOnly+Secure+SameSite session cookie) → `GET /auth/me` → `POST /auth/logout`.
- **`ApiKeyProvider`** wraps the existing module (headless `X-API-Key` still works, now timing-safe).
- **`GET /meta`** → `{edition, auth_modes}`. In-process **capture Mailer** (SMTP is a config swap).

### Endpoints
`POST /auth/signup` · `POST /auth/verify` · `POST /auth/login` · `GET /auth/me` · `POST /auth/logout` · `GET /meta`

### Verification
- **373 tests** (unit + integration + 15 ATDD acceptance) green; ruff/format/pyright clean.
- **Gate B security review: 11/11 invariants PASS, zero defects** — argon2id hashing; session & verification tokens high-entropy, stored **hashed**, expiring, single-use; cookies HttpOnly+Secure+SameSite=Lax; **timing-safe, no-user-enumeration** login (throwaway-hash equaliser); 100% parameterized SQL; no secret logging; fail-closed resolver.
- Live-socket smoke: `/products` 401 fail-closed (no cred / bad key), 200 with valid `X-API-Key`, `/meta` correct.

### Notes / follow-ups (non-blocking)
- Debug: a `TestClient` couldn't carry the `Secure` session cookie over http (test-transport only) → acceptance client uses https base_url; production posture unchanged.
- Fix: normalized login email (trim+lowercase) to match stored form (Gate B usability finding).
- Deferred (hygiene): periodic pruning of expired session/verification rows (they never authenticate; just accumulate).
- New dep: `argon2-cffi`. `mutmut` mutation testing still unwired (carried gap).

Closes #18. Plan: `docs/planning/P4_MULTIAGENT_EXECUTION_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
