### PR TITLE
feat(auth): P6 — EE (Stytch): StytchProvider + callback + Stytch login (LAV-37..40)

### DIFF
--- a/app/auth/auth_mode.py
+++ b/app/auth/auth_mode.py
@@ -10,8 +10,10 @@ class AuthMode(StrEnum):
     ``docs/design/API_CONTRACT.md`` §1). ``password`` (username/password +
     sessions) is added by the R2 lane; ``apikey`` is the headless ``X-API-Key``
     mode wired here in the foundation. The managed-identity ``stytch`` mode is
-    deferred and intentionally not represented.
+    the EE (P6) lane — it is only honoured when the deployment edition is
+    ``ee`` (see :meth:`app.auth.auth_settings.AuthSettings.modes`).
     """
 
     PASSWORD = "password"
     APIKEY = "apikey"
+    STYTCH = "stytch"

--- a/app/auth/auth_settings.py
+++ b/app/auth/auth_settings.py
@@ -21,9 +21,13 @@ class AuthSettings:
     _ALLOWED_DOMAINS_ENV_VAR: str = "LAVS_ALLOWED_EMAIL_DOMAINS"
     _SESSION_TTL_ENV_VAR: str = "LAVS_SESSION_TTL_SECONDS"
     _EDITION_ENV_VAR: str = "LAVS_EDITION"
+    _STYTCH_PROJECT_ID_ENV_VAR: str = "LAVS_STYTCH_PROJECT_ID"
+    _STYTCH_SECRET_ENV_VAR: str = "LAVS_STYTCH_SECRET"
+    _STYTCH_PUBLIC_TOKEN_ENV_VAR: str = "LAVS_STYTCH_PUBLIC_TOKEN"
 
     _DEFAULT_SESSION_TTL_SECONDS: int = 604800
     _DEFAULT_EDITION: str = "oss"
+    _EE_EDITION: str = "ee"
 
     def __init__(
         self,
@@ -31,6 +35,9 @@ class AuthSettings:
         allowed_email_domains: tuple[str, ...] | None = None,
         session_ttl_seconds: int | None = None,
         edition: str | None = None,
+        stytch_project_id: str | None = None,
+        stytch_secret: str | None = None,
+        stytch_public_token: str | None = None,
     ) -> None:
         """Initialise the settings.
 
@@ -44,11 +51,18 @@ class AuthSettings:
                 tuple means "allow all").
             session_ttl_seconds: Session lifetime in seconds.
             edition: The deployment edition label.
+            stytch_project_id: The Stytch project id (EE).
+            stytch_secret: The Stytch project secret (EE; never logged).
+            stytch_public_token: The Stytch publishable public token (EE; safe
+                to surface to browsers via ``/meta``).
         """
         self._modes = modes
         self._allowed_email_domains = allowed_email_domains
         self._session_ttl_seconds = session_ttl_seconds
         self._edition = edition
+        self._stytch_project_id = stytch_project_id
+        self._stytch_secret = stytch_secret
+        self._stytch_public_token = stytch_public_token
 
     @staticmethod
     def _split_csv(raw: str) -> list[str]:
@@ -58,8 +72,11 @@ class AuthSettings:
     def modes(self) -> set[AuthMode]:
         """Return the set of enabled authentication modes.
 
-        Unrecognised tokens (for example a future ``stytch``) are ignored so a
-        forward-compatible config never crashes the foundation.
+        Unrecognised tokens are ignored so a forward-compatible config never
+        crashes the foundation. The ``stytch`` token is edition-gated: it is
+        honoured only when :meth:`edition` is ``ee`` and stays ignored on an
+        OSS deployment — exactly the pre-EE behaviour (managed identity is an
+        EE capability; a stray ``stytch`` token cannot enable it on OSS).
         """
         if self._modes is not None:
             return set(self._modes)
@@ -71,6 +88,8 @@ class AuthSettings:
             lowered = token.lower()
             if lowered in valid_values:
                 recognised.add(AuthMode(lowered))
+        if AuthMode.STYTCH in recognised and self.edition() != self._EE_EDITION:
+            recognised.discard(AuthMode.STYTCH)
         return recognised
 
     def allowed_email_domains(self) -> tuple[str, ...]:
@@ -112,3 +131,41 @@ class AuthSettings:
     def apikey_mode_enabled(self) -> bool:
         """Return ``True`` when the ``apikey`` mode is explicitly enabled."""
         return AuthMode.APIKEY in self.modes()
+
+    def stytch_enabled(self) -> bool:
+        """Return ``True`` when the ``stytch`` mode is enabled (EE only)."""
+        return AuthMode.STYTCH in self.modes()
+
+    @staticmethod
+    def _optional_env(name: str) -> str | None:
+        """Return a trimmed env value, or ``None`` when unset or blank."""
+        raw = os.environ.get(name)
+        if raw is None or not raw.strip():
+            return None
+        return raw.strip()
+
+    def stytch_project_id(self) -> str | None:
+        """Return the Stytch project id, or ``None`` when unconfigured."""
+        if self._stytch_project_id is not None:
+            return self._stytch_project_id
+        return self._optional_env(self._STYTCH_PROJECT_ID_ENV_VAR)
+
+    def stytch_secret(self) -> str | None:
+        """Return the Stytch project secret, or ``None`` when unconfigured.
+
+        Read on demand and never logged — it is handed only to the Stytch SDK
+        client construction.
+        """
+        if self._stytch_secret is not None:
+            return self._stytch_secret
+        return self._optional_env(self._STYTCH_SECRET_ENV_VAR)
+
+    def stytch_public_token(self) -> str | None:
+        """Return the publishable Stytch public token, or ``None`` when unset.
+
+        This is the browser-safe publishable token surfaced through ``/meta``
+        (never the secret).
+        """
+        if self._stytch_public_token is not None:
+            return self._stytch_public_token
+        return self._optional_env(self._STYTCH_PUBLIC_TOKEN_ENV_VAR)

--- a/app/auth/providers/stytch_provider.py
+++ b/app/auth/providers/stytch_provider.py
@@ -1,0 +1,103 @@
+"""Provider that authenticates a request by its Stytch session credential."""
+
+from fastapi import Request
+
+from app.auth.auth_provider import AuthProvider
+from app.auth.principal import Principal
+from app.auth.principal_kind import PrincipalKind
+from app.auth.stytch.stytch_verifier import StytchVerifier
+from app.auth.users.user_repository import UserRepository
+from app.auth.users.user_status import UserStatus
+from app.connections.db_session import DbSession
+
+
+class StytchProvider(AuthProvider):
+    """Authenticate a request by a Stytch session token or session JWT (EE).
+
+    Reads the credential from the cookies the Stytch frontend SDK maintains
+    (``stytch_session_jwt`` preferred, ``stytch_session`` as fallback) and
+    verifies it through the injected :class:`StytchVerifier` — an abstraction
+    over the Stytch SDK so tests inject a fake and never touch the network.
+
+    A verified Stytch identity is **not** trusted on its own: the provider
+    resolves the mapped LAVS account by the Stytch-**verified** email (same
+    trim/lower normalization as the callback route) through the
+    :class:`UserRepository`, and mints a ``user`` principal only when that row
+    exists **and** is ``active`` — carrying the LAVS user id and the row's
+    email, never the raw Stytch id. This keeps a disabled LAVS user disabled
+    and an unmapped Stytch user unauthenticated even when their Stytch session
+    itself is valid. On any miss (no credential, invalid/expired token, an
+    unconfigured verifier, no verified email, no mapped row, a non-active row,
+    or no live database) it returns ``None`` so another provider, or the
+    resolver's 401, decides the request. It never raises for the not-me case.
+
+    Note the primary EE flow does not depend on this provider: the
+    ``POST /auth/stytch/callback`` route exchanges the Stytch token for a
+    normal ``lavs_session`` cookie, which the session-cookie provider then
+    authenticates. This provider covers callers presenting the Stytch
+    credential directly.
+    """
+
+    _SESSION_JWT_COOKIE: str = "stytch_session_jwt"
+    _SESSION_TOKEN_COOKIE: str = "stytch_session"
+
+    def __init__(
+        self,
+        edition: str,
+        verifier: StytchVerifier,
+        user_repository: UserRepository | None = None,
+    ) -> None:
+        """Initialise the provider.
+
+        Args:
+            edition: The edition stamped onto the resolved user principal.
+            verifier: The Stytch verification seam (SDK-backed in production,
+                a fake in tests).
+            user_repository: The user store the verified email is resolved
+                against. Defaults to a fresh
+                :class:`~app.auth.users.user_repository.UserRepository`.
+        """
+        self._edition = edition
+        self._verifier = verifier
+        self._user_repository = user_repository if user_repository is not None else UserRepository()
+
+    async def authenticate(self, request: Request) -> Principal | None:
+        """Authenticate the request via its Stytch session cookie.
+
+        Args:
+            request: The incoming request.
+
+        Returns:
+            A ``user`` principal when a presented Stytch credential verifies
+            **and** maps onto an ``active`` LAVS user by its verified email,
+            otherwise ``None``.
+        """
+        token = request.cookies.get(self._SESSION_JWT_COOKIE)
+        if token is None or token == "":
+            token = request.cookies.get(self._SESSION_TOKEN_COOKIE)
+        if token is None or token == "":
+            return None
+
+        verification = await self._verifier.verify(token)
+        if verification is None:
+            return None
+        if verification.email is None or not verification.email.strip():
+            return None
+        email = verification.email.strip().lower()
+
+        connection: DbSession | None = request.app.state.db_connection
+        if connection is None:
+            return None
+
+        user_row = await self._user_repository.get_user_by_email(connection, email)
+        if user_row is None:
+            return None
+        if str(user_row[3]) != UserStatus.ACTIVE.value:
+            return None
+
+        return Principal(
+            kind=PrincipalKind.USER,
+            id=str(user_row[0]),
+            email=str(user_row[1]),
+            edition=self._edition,
+        )

--- a/app/auth/stytch/stytch_sdk_verifier.py
+++ b/app/auth/stytch/stytch_sdk_verifier.py
@@ -1,0 +1,106 @@
+"""The production :class:`StytchVerifier` backed by the official Stytch SDK."""
+
+import logging
+
+from stytch import Client
+from stytch.consumer.models.users import User
+from stytch.core.response_base import StytchError
+
+from app.auth.auth_settings import AuthSettings
+from app.auth.stytch.stytch_verification import StytchVerification
+from app.auth.stytch.stytch_verifier import StytchVerifier
+
+logger = logging.getLogger("lavs-api")
+
+
+class StytchSdkVerifier(StytchVerifier):
+    """Verify Stytch session credentials through ``stytch.Client``.
+
+    The client is constructed lazily, on the first verification, from the
+    ``LAVS_STYTCH_PROJECT_ID`` / ``LAVS_STYTCH_SECRET`` accessors on
+    :class:`AuthSettings` — the secret is read on demand and never logged.
+    A token containing exactly two dots is treated as a session JWT, anything
+    else as an opaque session token (the two credential shapes Stytch issues).
+    Any verification failure — :class:`StytchError`, missing configuration, or
+    an unexpected transport error — resolves to ``None`` so the caller's single
+    generic 401 posture holds; the presented token itself is never logged.
+    """
+
+    def __init__(self, settings: AuthSettings | None = None, client: Client | None = None) -> None:
+        """Initialise the verifier.
+
+        Args:
+            settings: The deployment auth settings the client is built from.
+                Defaults to an environment-backed :class:`AuthSettings`.
+            client: An already-constructed Stytch client. When supplied it is
+                used as-is and no settings are read (test/DI seam).
+        """
+        self._settings = settings if settings is not None else AuthSettings()
+        self._client = client
+
+    def _resolve_client(self) -> Client | None:
+        """Return the Stytch client, building it from settings on first use."""
+        if self._client is not None:
+            return self._client
+
+        project_id = self._settings.stytch_project_id()
+        secret = self._settings.stytch_secret()
+        if not project_id or not secret:
+            logger.warning("Stytch verification requested but the project id/secret is not set.")
+            return None
+
+        self._client = Client(project_id=project_id, secret=secret)
+        return self._client
+
+    @staticmethod
+    def _primary_email(user: User) -> str | None:
+        """Return the user's first **verified** email, or ``None``.
+
+        Unverified addresses are never surfaced: the callback maps this email
+        onto the shared ``users`` table, so trusting an unverified address
+        would let an attacker claim a victim's account by merely *entering*
+        their email at Stytch. With no verified email the identity resolves
+        with ``email=None`` and the callers' generic-401 paths fail closed.
+        """
+        for email in user.emails:
+            if email.verified:
+                return email.email
+        return None
+
+    async def verify(self, token: str) -> StytchVerification | None:
+        """Verify a Stytch session token or session JWT via the SDK.
+
+        Args:
+            token: The raw Stytch session token or session JWT.
+
+        Returns:
+            The verified identity, or ``None`` on any failure (invalid or
+            expired token, missing configuration, or a transport error).
+        """
+        client = self._resolve_client()
+        if client is None:
+            return None
+
+        try:
+            if token.count(".") == 2:
+                response = await client.sessions.authenticate_async(session_jwt=token)
+            else:
+                response = await client.sessions.authenticate_async(session_token=token)
+        except StytchError as error:
+            # Log only the exception class and Stytch's own status/error_type —
+            # never the presented token and never the full error payload.
+            logger.warning(
+                "Stytch session verification failed: %s (status=%s, error_type=%s).",
+                type(error).__name__,
+                error.details.status_code,
+                error.details.error_type,
+            )
+            return None
+        except Exception:
+            logger.exception("Stytch session verification failed unexpectedly.")
+            return None
+
+        return StytchVerification(
+            user_id=response.user.user_id,
+            email=self._primary_email(response.user),
+        )

--- a/app/auth/stytch/stytch_verification.py
+++ b/app/auth/stytch/stytch_verification.py
@@ -1,0 +1,16 @@
+"""The identity a successful Stytch session verification resolves to."""
+
+from pydantic import BaseModel
+
+
+class StytchVerification(BaseModel):
+    """The verified Stytch identity, decoupled from the SDK response shape.
+
+    Carries only what LAVS needs to mint a principal and map the caller onto
+    the shared ``users`` table: the Stytch user id and the (Stytch-verified)
+    email. Keeping this a small local model means the provider, the callback
+    route, and the tests never depend on the Stytch SDK's own types.
+    """
+
+    user_id: str
+    email: str | None = None

--- a/app/auth/stytch/stytch_verifier.py
+++ b/app/auth/stytch/stytch_verifier.py
@@ -1,0 +1,27 @@
+"""Interface for verifying a Stytch session token or session JWT."""
+
+from app.auth.stytch.stytch_verification import StytchVerification
+
+
+class StytchVerifier:
+    """Interface every Stytch session verifier implements.
+
+    The seam between LAVS and the Stytch SDK: production wires the
+    SDK-backed :class:`~app.auth.stytch.stytch_sdk_verifier.StytchSdkVerifier`,
+    while tests inject a fake so no network is ever touched. A verifier maps a
+    presented token to a :class:`StytchVerification` on success and ``None`` on
+    **any** failure — it never raises for an invalid credential, mirroring the
+    provider contract in :class:`~app.auth.auth_provider.AuthProvider`.
+    """
+
+    async def verify(self, token: str) -> StytchVerification | None:
+        """Verify a Stytch session token or session JWT.
+
+        Args:
+            token: The raw Stytch session token or session JWT to verify.
+
+        Returns:
+            The verified identity, or ``None`` when the token is invalid,
+            expired, or verification is not possible.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} must implement verify()")

--- a/app/auth/stytch/stytch_verifier_dependency.py
+++ b/app/auth/stytch/stytch_verifier_dependency.py
@@ -1,0 +1,33 @@
+"""FastAPI dependency exposing the application-managed :class:`StytchVerifier`.
+
+Mirrors :func:`app.mail.mailer_dependency.get_mailer`: the concrete verifier is
+placed on ``app.state.stytch_verifier`` by the application lifespan (an
+SDK-backed verifier when the ``stytch`` mode is enabled). When the app was
+started without one — a bare ``TestClient``, or a deployment where stytch is
+disabled — an SDK verifier is created lazily and stored on ``app.state``; with
+no Stytch configuration it verifies nothing, so the callback keeps failing
+closed. Tests inject a fake by assigning ``app.state.stytch_verifier``.
+"""
+
+from fastapi import Request
+
+from app.auth.stytch.stytch_sdk_verifier import StytchSdkVerifier
+from app.auth.stytch.stytch_verifier import StytchVerifier
+
+
+def get_stytch_verifier(request: Request) -> StytchVerifier:
+    """Return the application-managed Stytch verifier.
+
+    Args:
+        request: The incoming request, used to reach ``app.state``.
+
+    Returns:
+        The live :class:`StytchVerifier` managed by the application lifespan,
+        or a lazily-created SDK verifier when none was installed.
+    """
+    state = request.app.state
+    verifier = state.stytch_verifier if hasattr(state, "stytch_verifier") else None
+    if verifier is None:
+        verifier = StytchSdkVerifier()
+        state.stytch_verifier = verifier
+    return verifier

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,9 @@ from fastapi import FastAPI, Request, Response
 from app.auth.auth_resolver_factory import AuthResolverFactory
 from app.auth.auth_settings import AuthSettings
 from app.auth.providers.password_session_provider import PasswordSessionProvider
+from app.auth.providers.stytch_provider import StytchProvider
+from app.auth.stytch.stytch_sdk_verifier import StytchSdkVerifier
+from app.auth.stytch.stytch_verifier import StytchVerifier
 from app.backends.backend_factory import BackendFactory
 from app.connections.db_session import DbSession
 from app.database.migration.flat_to_relational_migration import FlatToRelationalMigration
@@ -53,6 +56,18 @@ async def lifespan(application: FastAPI) -> AsyncIterator[None]:
         auth_registry = AuthResolverFactory.build_registry(auth_settings)
         if auth_settings.password_enabled():
             auth_registry.register(PasswordSessionProvider(edition=auth_settings.edition()))
+        stytch_verifier: StytchVerifier | None = None
+        if auth_settings.stytch_enabled():
+            stytch_verifier = StytchSdkVerifier(settings=auth_settings)
+            auth_registry.register(
+                StytchProvider(edition=auth_settings.edition(), verifier=stytch_verifier)
+            )
+            if not auth_settings.password_enabled():
+                # Stytch-only deployments still authenticate the lavs_session
+                # cookie minted by /auth/stytch/callback via the session
+                # provider; with password enabled it is already registered.
+                auth_registry.register(PasswordSessionProvider(edition=auth_settings.edition()))
+        application.state.stytch_verifier = stytch_verifier
         application.state.auth_settings = auth_settings
         application.state.auth_registry = auth_registry
         application.state.auth_resolver = AuthResolverFactory.build_resolver(
@@ -72,6 +87,7 @@ async def lifespan(application: FastAPI) -> AsyncIterator[None]:
             application.state.auth_settings = None
             application.state.auth_registry = None
             application.state.auth_resolver = None
+            application.state.stytch_verifier = None
             application.state.mailer = None
             logger.info("Managed database session closed for application lifespan.")
 

--- a/app/models/requests/stytch_callback_model.py
+++ b/app/models/requests/stytch_callback_model.py
@@ -1,0 +1,22 @@
+"""Request body for ``POST /auth/stytch/callback`` (EE)."""
+
+from typing import Annotated
+
+from annotated_types import MinLen
+
+from app.models.requests.request_model import RequestModel
+
+
+class StytchCallbackModel(RequestModel):
+    """JSON body carrying the Stytch session credential to exchange.
+
+    ``stytch_token`` is the session token or session JWT the Stytch frontend
+    SDK produced; the backend verifies it and issues its own ``lavs_session``
+    cookie (see ``docs/design/API_CONTRACT.md`` §2). Required and non-empty —
+    an omitted token is a 422 (malformed) rather than a 401 (bad credentials).
+    The token is never logged or persisted.
+    """
+
+    stytch_token: Annotated[str, MinLen(1)]
+
+    model_config = {"json_schema_extra": {"examples": [{"stytch_token": "WJtR5BCy38..."}]}}

--- a/app/models/responses/meta_response_model.py
+++ b/app/models/responses/meta_response_model.py
@@ -9,10 +9,16 @@ class MetaResponseModel(ResponseModel):
     See ``docs/design/API_CONTRACT.md`` §8: the UI branches on ``edition`` and
     the enabled ``auth_modes`` (password form vs configured-key vs Stytch
     widget). Public — it must be reachable before a principal exists.
+    ``stytch_public_token`` is the browser-safe publishable Stytch token the
+    EE login widget initialises with; it is ``None`` outside EE/stytch
+    deployments (never the project secret) and the ``/meta`` route serializes
+    with ``exclude_none`` so the key is **omitted** when unset, keeping the
+    OSS response body byte-identical to its pre-EE shape.
     """
 
     edition: str
     auth_modes: list[str]
+    stytch_public_token: str | None = None
 
     model_config = {
         "json_schema_extra": {

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -24,6 +24,8 @@ Security posture of the login lane:
 import secrets
 from typing import Annotated
 
+import duckdb
+import psycopg.errors
 from fastapi import APIRouter, Depends, Request, Response, status
 
 from app.auth.auth_settings import AuthSettings
@@ -33,6 +35,8 @@ from app.auth.session.session_cookie import SessionCookie
 from app.auth.session.session_service import SessionService
 from app.auth.signup.signup_service import SignupService
 from app.auth.signup.verification_service import VerificationService
+from app.auth.stytch.stytch_verifier import StytchVerifier
+from app.auth.stytch.stytch_verifier_dependency import get_stytch_verifier
 from app.auth.users.user_repository import UserRepository
 from app.auth.users.user_status import UserStatus
 from app.connections.db_dependency import get_db_connection
@@ -42,14 +46,17 @@ from app.mail.mailer import Mailer
 from app.mail.mailer_dependency import get_mailer
 from app.models.requests.login_model import LoginModel
 from app.models.requests.signup_model import SignupModel
+from app.models.requests.stytch_callback_model import StytchCallbackModel
 from app.models.requests.verify_model import VerifyModel
 from app.models.responses.signup_accepted_model import SignupAcceptedModel
 from app.models.responses.user_response_model import UserResponseModel
+from app.models.types.ulid_id import new_ulid
 
 router = APIRouter(tags=["auth"], prefix="/auth")
 
 DbConnection = Annotated[DbSession, Depends(get_db_connection)]
 MailerDep = Annotated[Mailer, Depends(get_mailer)]
+StytchVerifierDep = Annotated[StytchVerifier, Depends(get_stytch_verifier)]
 
 _GENERIC_LOGIN_FAILURE = "invalid credentials"
 
@@ -75,6 +82,29 @@ def _auth_settings(request: Request) -> AuthSettings:
     state = request.app.state
     settings = state.auth_settings if hasattr(state, "auth_settings") else None
     return settings if settings is not None else AuthSettings()
+
+
+def _set_session_cookie(response: Response, token: str, ttl_seconds: int) -> None:
+    """Set the hardened ``lavs_session`` cookie on a response.
+
+    One place for the cookie flags so every session-establishing route
+    (``/auth/login``, ``/auth/stytch/callback``) issues the byte-identical
+    ``HttpOnly``/``Secure``/``SameSite=Lax`` cookie.
+
+    Args:
+        response: The outgoing response to set the cookie on.
+        token: The raw session token minted for the caller.
+        ttl_seconds: The session (and cookie) lifetime in seconds.
+    """
+    response.set_cookie(
+        key=SessionCookie.NAME,
+        value=token,
+        max_age=ttl_seconds,
+        httponly=SessionCookie.HTTP_ONLY,
+        secure=SessionCookie.SECURE,
+        samesite=SessionCookie.SAME_SITE,
+        path=SessionCookie.PATH,
+    )
 
 
 @router.post(
@@ -168,22 +198,166 @@ async def login(
     settings = _auth_settings(request)
     ttl_seconds = settings.session_ttl_seconds()
     token = SessionService().create_session(conn, user_id=str(user_row[0]), ttl_seconds=ttl_seconds)
-
-    response.set_cookie(
-        key=SessionCookie.NAME,
-        value=token,
-        max_age=ttl_seconds,
-        httponly=SessionCookie.HTTP_ONLY,
-        secure=SessionCookie.SECURE,
-        samesite=SessionCookie.SAME_SITE,
-        path=SessionCookie.PATH,
-    )
+    _set_session_cookie(response, token=token, ttl_seconds=ttl_seconds)
 
     return UserResponseModel(
         id=str(user_row[0]),
         email=str(user_row[1]),
         status=str(user_row[3]),
         edition=None if user_row[4] is None else str(user_row[4]),
+    )
+
+
+def _assert_stytch_domain_allowed(email: str, settings: AuthSettings) -> None:
+    """Enforce the email-domain allow-list on the Stytch callback lane.
+
+    Uses the same normalization semantics as ``SignupService`` (the allow-list
+    is lower-cased by :meth:`AuthSettings.allowed_email_domains`, the domain is
+    everything after the last ``@`` of the already-lowered email, and an empty
+    allow-list means every domain is allowed) but fails with the **generic
+    401** rather than signup's 403 ``DomainNotAllowedError``: on a credential
+    lane a distinct status would let a probe fingerprint the allow-list.
+
+    Posture: the check applies to **existing** mapped users as well as
+    first-sight creations (defense in depth) — an operator who tightens the
+    allow-list expects previously-mapped users outside it to stop
+    authenticating through Stytch, not to be grandfathered in.
+
+    Args:
+        email: The normalised (trimmed, lower-cased) Stytch-verified email.
+        settings: The auth settings carrying the allow-list.
+
+    Raises:
+        UnauthorizedError: When a non-empty allow-list excludes the domain.
+    """
+    allowed = settings.allowed_email_domains()
+    if not allowed:
+        return
+    domain = email.rsplit("@", 1)[-1]
+    if domain not in allowed:
+        raise UnauthorizedError(message=_GENERIC_LOGIN_FAILURE)
+
+
+async def _existing_stytch_user(
+    repository: UserRepository, conn: DbSession, user_row: tuple[object, ...]
+) -> tuple[str, str | None]:
+    """Map an existing user row for the Stytch callback lane.
+
+    A ``disabled`` row is refused with the generic 401; a ``pending`` row is
+    activated (Stytch has verified the email).
+
+    Args:
+        repository: The users-table repository.
+        conn: The live database connection.
+        user_row: The raw ``users`` row for the verified email.
+
+    Returns:
+        The ``(user_id, user_edition)`` pair for the session and response.
+
+    Raises:
+        UnauthorizedError: When the account is disabled — same generic message
+            as every other callback failure (no enumeration).
+    """
+    if str(user_row[3]) == UserStatus.DISABLED.value:
+        raise UnauthorizedError(message=_GENERIC_LOGIN_FAILURE)
+    user_id = str(user_row[0])
+    user_edition = None if user_row[4] is None else str(user_row[4])
+    if str(user_row[3]) == UserStatus.PENDING.value:
+        await repository.activate_user(conn, user_id)
+    return user_id, user_edition
+
+
+@router.post("/stytch/callback", response_model=UserResponseModel)
+async def stytch_callback(
+    body: StytchCallbackModel,
+    request: Request,
+    response: Response,
+    conn: DbConnection,
+    verifier: StytchVerifierDep,
+) -> UserResponseModel:
+    """Exchange a verified Stytch session token for a ``lavs_session`` (EE).
+
+    Active only when the ``stytch`` auth mode is enabled (EE deployments):
+    when it is not, the route answers with the same generic 401 as any bad
+    credential, so a probe cannot distinguish "disabled" from "invalid". On
+    success the token is verified through the injected
+    :class:`~app.auth.stytch.stytch_verifier.StytchVerifier`, the caller is
+    mapped onto the shared ``users`` table by their Stytch-verified email
+    (created ``active`` on first sight; an existing ``pending`` user is
+    activated, since Stytch has verified the email), and a normal server-side
+    session is opened with the identical hardened cookie as ``/auth/login``.
+    The email-domain allow-list is enforced on this lane for first-sight
+    creations **and** existing mapped users (see
+    :func:`_assert_stytch_domain_allowed`), and a concurrent first-sight race
+    on the unique email column is absorbed by adopting the winning row. On
+    **any** verification failure a single generic 401 is returned; the token
+    is never logged or persisted.
+
+    Args:
+        body: The callback body carrying the raw Stytch token.
+        request: The incoming request, used to read the deployment settings.
+        response: The outgoing response, used to set the session cookie.
+        conn: The application-managed database connection.
+        verifier: The Stytch verification seam (injected).
+
+    Returns:
+        The authenticated user as a safe :class:`UserResponseModel`.
+
+    Raises:
+        UnauthorizedError: When the ``stytch`` mode is disabled, the token
+            does not verify, the verified identity carries no verified email,
+            the email's domain is outside a configured allow-list, or the
+            mapped account is disabled — always with the same generic message.
+    """
+    settings = _auth_settings(request)
+    if not settings.stytch_enabled():
+        raise UnauthorizedError(message=_GENERIC_LOGIN_FAILURE)
+
+    verification = await verifier.verify(body.stytch_token)
+    if verification is None or verification.email is None or not verification.email.strip():
+        raise UnauthorizedError(message=_GENERIC_LOGIN_FAILURE)
+
+    email = verification.email.strip().lower()
+    _assert_stytch_domain_allowed(email, settings)
+    repository = UserRepository()
+    user_row = await repository.get_user_by_email(conn, email)
+
+    if user_row is None:
+        # Stytch-born users have no LAVS password; store an unusable random
+        # hash (mirroring the timing-equaliser approach) so the row satisfies
+        # the schema yet can never authenticate through /auth/login.
+        try:
+            created = await repository.create_user(
+                conn,
+                user_id=new_ulid(),
+                email=email,
+                password_hash=PasswordHasher().hash_password(secrets.token_urlsafe(32)),
+                status=UserStatus.ACTIVE,
+                edition=settings.edition(),
+            )
+            user_id = created.id
+            user_edition = created.edition
+        except duckdb.ConstraintException, psycopg.errors.UniqueViolation:
+            # A concurrent first-sight callback won the insert race; adopt the
+            # row it created instead of surfacing a duplicate-key 500.
+            user_row = await repository.get_user_by_email(conn, email)
+            if user_row is None:
+                # ``from None``: the driver's message may embed row values and
+                # must not chain into the generic credential failure.
+                raise UnauthorizedError(message=_GENERIC_LOGIN_FAILURE) from None
+            user_id, user_edition = await _existing_stytch_user(repository, conn, user_row)
+    else:
+        user_id, user_edition = await _existing_stytch_user(repository, conn, user_row)
+
+    ttl_seconds = settings.session_ttl_seconds()
+    token = SessionService().create_session(conn, user_id=user_id, ttl_seconds=ttl_seconds)
+    _set_session_cookie(response, token=token, ttl_seconds=ttl_seconds)
+
+    return UserResponseModel(
+        id=user_id,
+        email=email,
+        status=UserStatus.ACTIVE.value,
+        edition=user_edition,
     )
 
 

--- a/app/routers/meta.py
+++ b/app/routers/meta.py
@@ -42,9 +42,14 @@ def _enabled_auth_modes(settings: AuthSettings) -> list[str]:
     return sorted(mode.value for mode in modes)
 
 
-@router.get("/meta", response_model=MetaResponseModel)
+@router.get("/meta", response_model=MetaResponseModel, response_model_exclude_none=True)
 def get_meta(request: Request) -> MetaResponseModel:
     """Report the deployment edition and enabled auth modes.
+
+    ``response_model_exclude_none`` keeps the OSS response byte-identical to
+    its pre-EE shape: ``stytch_public_token`` appears only when a token is
+    configured (EE + stytch). ``edition`` and ``auth_modes`` are never ``None``
+    so the exclusion can never drop them.
 
     Args:
         request: The incoming request, used to reach the managed settings.
@@ -56,4 +61,5 @@ def get_meta(request: Request) -> MetaResponseModel:
     return MetaResponseModel(
         edition=settings.edition(),
         auth_modes=_enabled_auth_modes(settings),
+        stytch_public_token=settings.stytch_public_token() if settings.stytch_enabled() else None,
     )

--- a/docs/planning/ENVIRONMENT.md
+++ b/docs/planning/ENVIRONMENT.md
@@ -1,3 +1,21 @@
+# P6 Environment Manifest — 2026-07-23, branch `feat/20-p6-ee-stytch`. **Gate: GREEN.**
+
+First **full-stack** phase (BE + FE lanes). BE from repo root via `uv`; FE from `frontend/ui`.
+
+| # | Item | Status | Verify |
+|---|---|---|---|
+| E1 | BE baseline @ `11ac6da` | ✅ 412 pytest · ruff clean | pre-change baseline |
+| E2 | FE baseline @ `11ac6da` | ✅ 107 vitest · build green | pre-change baseline |
+| E3 | `stytch` python SDK | ✅ 15.3.0 | `uv add stytch`; import OK; `Sessions.authenticate(_async)` + `AuthenticateResponse{session,user}` surface confirmed |
+| E4 | `@stytch/vanilla-js` | ✅ 6.0.11 | `pnpm add`; build + 107 tests still green (pnpm store relinked after snap move) |
+| E5 | Fake Stytch verifier | ✅ | provider takes an injected client; fake mirrors `sessions.authenticate_async(session_token=…) → AuthenticateResponse`-shaped object; no network in tests (G-P6b) |
+
+New deps (flagged, per G-P6a): **`stytch` 15.3.0** (BE runtime) · **`@stytch/vanilla-js` 6.0.11** (FE prebuilt widget).
+No live Stytch tenant required for any gate (G-P6b) — manual smoke doc post-merge.
+Readiness: `P6_ENV_READY=GREEN`.
+
+---
+
 # P5 Environment Manifest — 2026-07-12, branch `feat/19-p5-frontend`. **Gate: GREEN.**
 
 First **frontend** environment. All FE-local under `frontend/ui`; backend untouched. Run commands

--- a/docs/planning/P6_MULTIAGENT_EXECUTION_PLAN.md
+++ b/docs/planning/P6_MULTIAGENT_EXECUTION_PLAN.md
@@ -1,0 +1,119 @@
+# P6 EE (Stytch) — Multiagent Parallel Execution Plan
+
+> **Status:** ✅ **EXECUTED (2026-07-23).** Approved with all four default decisions (G-P6b/c/e/f).
+> Branch `feat/20-p6-ee-stytch` off `main` @ `11ac6da`. Epic #20 · Linear LAV-37..40.
+> Lanes B1 ∥ F1 → aggregation → Gate A PASS (5 MINOR, fixed) → Gate B FAIL (3 HIGH:
+> unverified-email ATO, provider users-table bypass, allowlist skip) → debug pass (retry 1/2)
+> → Gate B re-check PASS → Gate C: BE 466 pytest + ruff/format/pyright · FE 118 vitest +
+> typecheck/lint/build · Playwright 4/4. OSS `/meta` byte-identical (`response_model_exclude_none`).
+
+Implement the **EE managed-identity path**: a backend `StytchProvider` that verifies a Stytch
+session and issues the normal `lavs_session` cookie (`POST /auth/stytch/callback`, API_CONTRACT §2),
+plus the **frontend Stytch login** rendered when `/meta` advertises `stytch`. OSS behavior is
+untouched — acceptance is literally "the OSS build and all resource routes are unchanged."
+
+---
+
+## 1. Conventions loaded
+`.claude/conventions/languages/python.md` (BE: 3.14/uv/pytest/ruff, exceptions-style errors) ·
+`.claude/conventions/languages/typescript.md` (FE: strict, no `any`, kebab/named-exports/barrels,
+vitest+MSW, coverage L80/B70/F90/S85) · `API_CONTRACT.md` §1–2 (auth modes, provider abstraction,
+`POST /auth/stytch/callback {stytch_token}` → verify → issue `lavs_session`; the rest of the API is
+identical regardless of how the `Principal` was obtained) · `ROADMAP.md` P6 (exit criteria).
+**Gaps flagged:** G-P6a Stytch SDK deps (BE `stytch`; FE `@stytch/vanilla-js`) · G-P6b no live
+Stytch tenant in CI → provider-boundary fakes + manual smoke · G-P6c edition wiring (`LAVS_EDITION`)
+· G-P6d `auth_settings` currently *ignores* the `stytch` token — must start honoring it (EE only).
+
+## 2. Agent roster → P6 roles
+Orchestration=harness · env-runner=`devops-agent` (deps + green baselines) · **B1** backend
+Stytch provider=`backend-agent`+`security-agent` · **F1** frontend Stytch login=`frontend-agent` ·
+tests=`test-agent` per lane · enforcement=`enforcement-agent` (A) · security=`security-agent`
+(B — token handling/JWT verification/cookie issuance) · integration=`review-agent` (C) · debug=`debug-agent`.
+
+## 3. Environment manifest (hard prerequisite gate)
+| # | Item | Health check | Notes |
+|---|---|---|---|
+| E1 | BE baseline | `uv run pytest -q` green @ `11ac6da`; pyright/ruff clean | pre-change baseline |
+| E2 | FE baseline | `pnpm test` (107) + `pnpm e2e` + build green | pre-change baseline |
+| E3 | `stytch` python SDK | `uv add stytch` + import OK | G-P6a; runtime dep, flagged |
+| E4 | `@stytch/vanilla-js` | `pnpm add` + build OK | G-P6a; FE-local, flagged |
+| E5 | Fake Stytch verifier | unit-injectable fake client passes a sample verify | no network in tests (G-P6b) |
+
+Any hard failure ⇒ escalate. No live Stytch tenant is required for any gate (G-P6b); a real-tenant
+manual smoke runs post-merge when credentials exist.
+
+## 4. Scope
+**In:** `StytchProvider.authenticate` (verify Stytch session JWT/token via SDK, map to `Principal
+(kind=user, edition=ee)`) · `POST /auth/stytch/callback {stytch_token}` → verify → create the normal
+server-side session + `HttpOnly lavs_session` cookie · honor `stytch` in `LAVS_AUTH_MODES` **iff**
+`LAVS_EDITION=ee` (else ignored, as today) · `/meta` reports `edition:"ee"` + `stytch` mode · FE:
+replace the `LoginForm` "managed sign-in — coming soon" branch with the **Stytch widget**
+(magic-link + OAuth), exchange the returned token at the callback route, then the normal
+`/auth/me` session flow; mixed-mode UI (password *and* stytch both enabled) renders both paths ·
+tests both sides with fakes/MSW. **Out:** RBAC/orgs · SCIM/provisioning · MFA policy config ·
+changing any resource route or OSS default (`LAVS_AUTH_MODES=password,apikey` stays).
+
+## 5. Execution map
+```mermaid
+flowchart TB
+    START([✅ approve]) --> ENV["🔒 env-setup E1–E5 (baselines + SDKs + fake verifier)"]
+    ENV -- fail --> BLOCK[["⛔ escalate"]]
+    ENV -- green --> FAN{{fan out — 2 lanes}}
+    FAN --> B1 & F1
+    subgraph LANES["⫶ parallel lanes"]
+      B1["B1 · backend: StytchProvider + /auth/stytch/callback + LAVS_EDITION + settings honor 'stytch' (EE only) + /meta ee · pytest w/ faked SDK"]
+      F1["F1 · frontend: stytch login branch in LoginForm (widget → callback exchange → session) + mixed-mode UI · vitest/MSW (SDK stubbed)"]
+    end
+    B1 & F1 --> AGG["🧮 aggregate (contract check: callback shape, /meta values)"]
+    AGG --> GA["Gate A enforcement (both conventions)"]
+    GA --> GB["Gate B security: real JWT verification (no decode-without-verify) · token never persisted/logged · cookie flags · no Stytch secrets in FE bundle (publishable token only) · OSS untouched"]
+    GB --> GC["Gate C integration: full BE+FE suites green · OSS regression (password/apikey unchanged) · EE flow vs faked Stytch e2e-style test · builds"]
+    GC -- green --> DONE([🎉 signed PR → main])
+    GC -- fail --> DBG["debug-agent · failing lane only, max 2×"] --> AGG
+```
+
+## 6. Subagent specification
+- **env-setup:** E1–E5; update `ENVIRONMENT.md` (`P6_ENV_READY`).
+- **B1 (backend):** `app/auth/providers/stytch_provider.py` implementing `AuthProvider` (inject the
+  Stytch client; verify session; map to `Principal`); callback route in the auth router (`202/401`
+  per error model); `LAVS_EDITION` setting (default `oss`); `auth_settings` honors `stytch` only in
+  EE (G-P6d); `/meta` reflects it; registry wiring. Tests: fake SDK — valid/expired/garbage token,
+  OSS-mode rejection, settings matrix, callback → session cookie round-trip.
+- **F1 (frontend):** `stytch-login.tsx` under `src/features/auth/` (new files only, same lane rules
+  as P5): load widget with the **publishable** token from `/meta` (extend `Meta` type optionally) or
+  env; on Stytch success POST `{stytch_token}` to callback via the typed client (new `api/auth.ts`
+  fn `stytchCallback`); then normal session flow. `LoginForm` renders it when `stytch` enabled;
+  both-modes layout. MSW handler for the callback; widget stubbed in tests.
+- **Gates/Aggregator/Debug:** as P5; Gate B is the heavyweight here (see map).
+
+## 7. Test strategy
+BE: pytest with an injected fake Stytch client (no network) — provider matrix + callback flow + OSS
+regression suite untouched. FE: vitest/MSW — mode-matrix rendering (password / stytch / both /
+apikey-only), callback exchange, error surfaces; widget itself stubbed (it's Stytch's code, not
+ours). Gate C: both full suites + builds + the P5 Playwright suite still green (OSS path).
+
+## 8. Gap report & decisions to sanity-check
+| ID | Item | Decision / fallback |
+|---|---|---|
+| **G-P6a** | New deps | BE **`stytch`** (runtime) · FE **`@stytch/vanilla-js`** (prebuilt widget). Flagged. |
+| **G-P6b** | No Stytch tenant in CI | Verify at the provider boundary with an injected fake; **no live-network test**. Manual smoke doc for when a tenant exists. |
+| **G-P6c** | Edition flag | New env **`LAVS_EDITION=oss|ee`** (default `oss`); `stytch` in `LAVS_AUTH_MODES` honored only when `ee`. |
+| **G-P6d** | Settings today ignore `stytch` | Start honoring it per G-P6c — a deliberate, tested behavior change (EE only). |
+| **G-P6e** | Stytch surface | **Consumer** product, passwordless **magic links + OAuth** via the prebuilt widget (roadmap says "Stytch widget"). B2B/organizations deferred. |
+| **G-P6f** | Publishable token delivery | Served via `/meta` (optional field) so one FE build works per-deploy; fallback `VITE_STYTCH_PUBLIC_TOKEN`. |
+
+## 9. Debug & retry
+As P5: failures surface at Gates A/B/C; retry failing lane only, max 2×; escalate on Stytch-SDK
+surprises (API shape drift), any OSS regression, or a security finding at Gate B. Pause + re-present
+on material change.
+
+---
+
+## Approval
+**On approval:** create `feat/20-p6-ee-stytch` + Linear issues (epic + env/B1/F1/gates) → env-setup
+→ fan out **B1 ∥ F1** → aggregate → Gates A/B/C → signed PR → `main` (#20).
+
+**Four decisions to confirm** (defaults above): (a) **consumer Stytch + prebuilt widget** (magic
+link + OAuth), B2B deferred (G-P6e); (b) **no live-Stytch test** — fakes at the provider boundary +
+manual smoke doc (G-P6b); (c) **`LAVS_EDITION` env** gates the mode (G-P6c/d); (d) publishable
+token via **`/meta`** (G-P6f). **Reply to approve, or redirect.**

--- a/frontend/ui/package.json
+++ b/frontend/ui/package.json
@@ -21,6 +21,7 @@
     "e2e:install": "playwright install --with-deps chromium"
   },
   "dependencies": {
+    "@stytch/vanilla-js": "^6.0.11",
     "@tanstack/react-query": "^5.62.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/frontend/ui/pnpm-lock.yaml
+++ b/frontend/ui/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@stytch/vanilla-js':
+        specifier: ^6.0.11
+        version: 6.0.11
       '@tanstack/react-query':
         specifier: ^5.62.7
         version: 5.101.2(react@19.2.7)
@@ -660,6 +663,9 @@ packages:
     resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
+
+  '@stytch/vanilla-js@6.0.11':
+    resolution: {integrity: sha512-EpFCwCeevzxZIzJSQ0JHH8JFtUz0XzF8sy4rtuL95QflMSrdLVf1BWC1JdQtZGKpYw9IpBkRlLDONzzSveye7Q==}
 
   '@tanstack/query-core@5.101.2':
     resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
@@ -2438,6 +2444,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
+
+  '@stytch/vanilla-js@6.0.11': {}
 
   '@tanstack/query-core@5.101.2': {}
 

--- a/frontend/ui/src/api/auth.ts
+++ b/frontend/ui/src/api/auth.ts
@@ -21,6 +21,14 @@ export function logout(): Promise<Result<void>> {
   return http.post<void>('/auth/logout');
 }
 
+/**
+ * EE: exchange a Stytch session token/JWT for a LAVS session. The backend verifies the
+ * token with Stytch, sets the HttpOnly `lavs_session` cookie, and returns the principal.
+ */
+export function stytchCallback(stytchToken: string): Promise<Result<Principal>> {
+  return http.post<Principal>('/auth/stytch/callback', { stytch_token: stytchToken });
+}
+
 /** Deploy config: edition + enabled auth modes, so the UI renders the right login. */
 export function getMeta(signal?: AbortSignal): Promise<Result<Meta>> {
   return http.get<Meta>('/meta', { signal });

--- a/frontend/ui/src/api/index.ts
+++ b/frontend/ui/src/api/index.ts
@@ -5,7 +5,7 @@ export { getTimeline, listProducts } from './products';
 export { cutRelease, getRelease, listReleases } from './releases';
 export type { CutReleaseInput } from './releases';
 
-export { getMe, getMeta, login, logout } from './auth';
+export { getMe, getMeta, login, logout, stytchCallback } from './auth';
 export type { Credentials } from './auth';
 
 export { subscribeToProductEvents } from './events';

--- a/frontend/ui/src/features/auth/auth-context.ts
+++ b/frontend/ui/src/features/auth/auth-context.ts
@@ -10,6 +10,11 @@ export interface AuthContextValue {
   readonly meta: Meta | null;
   readonly status: AuthStatus;
   readonly login: (credentials: Credentials) => Promise<Result<Principal>>;
+  /**
+   * EE: exchange a Stytch session token for a LAVS session and update auth state,
+   * mirroring how `login` promotes the returned principal into the cache.
+   */
+  readonly completeStytchLogin: (stytchToken: string) => Promise<Result<Principal>>;
   readonly logout: () => Promise<void>;
 }
 

--- a/frontend/ui/src/features/auth/auth-provider.tsx
+++ b/frontend/ui/src/features/auth/auth-provider.tsx
@@ -1,7 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, type ReactNode } from 'react';
 
-import { getMe, getMeta, login as loginRequest, logout as logoutRequest } from '@/api';
+import {
+  getMe,
+  getMeta,
+  login as loginRequest,
+  logout as logoutRequest,
+  stytchCallback,
+} from '@/api';
 import type { Credentials } from '@/api';
 import { queryKeys, unwrap } from '@/lib';
 import { ApiError } from '@/types';
@@ -37,6 +43,18 @@ export function AuthProvider({ children }: { readonly children: ReactNode }): Re
     [loginMutation],
   );
 
+  const stytchMutation = useMutation({
+    mutationFn: (stytchToken: string) => stytchCallback(stytchToken),
+    onSuccess: (result) => {
+      if (result.ok) queryClient.setQueryData(queryKeys.me, result.value);
+    },
+  });
+
+  const completeStytchLogin = useCallback(
+    (stytchToken: string) => stytchMutation.mutateAsync(stytchToken),
+    [stytchMutation],
+  );
+
   const logout = useCallback(async (): Promise<void> => {
     await logoutRequest();
     queryClient.setQueryData(queryKeys.me, null);
@@ -58,9 +76,19 @@ export function AuthProvider({ children }: { readonly children: ReactNode }): Re
       // A non-401 error still resolves to unauthenticated for gating purposes.
       status: meQuery.isError && !isUnauthorized ? 'unauthenticated' : status,
       login,
+      completeStytchLogin,
       logout,
     }),
-    [meQuery.data, meQuery.isError, metaQuery.data, isUnauthorized, status, login, logout],
+    [
+      meQuery.data,
+      meQuery.isError,
+      metaQuery.data,
+      isUnauthorized,
+      status,
+      login,
+      completeStytchLogin,
+      logout,
+    ],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/ui/src/features/auth/index.ts
+++ b/frontend/ui/src/features/auth/index.ts
@@ -3,4 +3,6 @@ export type { AuthContextValue, AuthStatus } from './auth-context';
 export { AuthProvider } from './auth-provider';
 export { LoginForm } from './login-form';
 export type { LoginFormProps } from './login-form';
+export { StytchLogin } from './stytch-login';
+export type { StytchLoginProps } from './stytch-login';
 export { useAuth } from './use-auth';

--- a/frontend/ui/src/features/auth/login-form.module.css
+++ b/frontend/ui/src/features/auth/login-form.module.css
@@ -65,3 +65,27 @@
   flex-direction: column;
   gap: 8px;
 }
+
+/* Mixed-mode (password + stytch) layout. */
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.separator {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--muted);
+  font-size: 12px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+}
+
+.separator::before,
+.separator::after {
+  content: '';
+  flex: 1;
+  border-top: 1px solid var(--line);
+}

--- a/frontend/ui/src/features/auth/login-form.test.tsx
+++ b/frontend/ui/src/features/auth/login-form.test.tsx
@@ -8,6 +8,23 @@ import { renderWithProviders } from '@/test';
 
 import { LoginForm } from './login-form';
 
+// Stub the Stytch SDK — the prebuilt widget is Stytch's code; these tests only
+// assert which login paths LoginForm renders per /meta auth_modes.
+vi.mock('@stytch/vanilla-js', () => {
+  class StytchUIClient {
+    readonly session = { getTokens: (): null => null };
+    mountLogin(): void {}
+  }
+  return {
+    StytchUIClient,
+    Products: {
+      emailMagicLinks: { id: 'emailMagicLinks', screens: {} },
+      oauth: { id: 'oauth', screens: {} },
+    },
+    StytchEventType: { AuthenticateFlowComplete: 'AUTHENTICATE_FLOW_COMPLETE' },
+  };
+});
+
 describe('LoginForm', () => {
   it('renders the password form under default meta (password,apikey)', () => {
     renderWithProviders(<LoginForm />);
@@ -55,13 +72,72 @@ describe('LoginForm', () => {
     expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
   });
 
-  it('shows a managed sign-in placeholder for stytch-only deployments', async () => {
+  it('renders the Stytch managed sign-in for stytch-only deployments', async () => {
     server.use(
-      http.get('*/api/meta', () => HttpResponse.json({ edition: 'ee', auth_modes: ['stytch'] })),
+      http.get('*/api/meta', () =>
+        HttpResponse.json({
+          edition: 'ee',
+          auth_modes: ['stytch'],
+          stytch_public_token: 'pk-test-token',
+        }),
+      ),
     );
     renderWithProviders(<LoginForm />);
 
-    await waitFor(() => expect(screen.getByText(/coming soon/i)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /managed sign-in/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('stytch-widget')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
+  });
+
+  it('renders both password and Stytch paths in mixed mode', async () => {
+    server.use(
+      http.get('*/api/meta', () =>
+        HttpResponse.json({
+          edition: 'ee',
+          auth_modes: ['password', 'stytch'],
+          stytch_public_token: 'pk-test-token',
+        }),
+      ),
+    );
+    renderWithProviders(<LoginForm />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /managed sign-in/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole('heading', { name: /^sign in$/i })).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+    expect(screen.getByRole('separator')).toBeInTheDocument();
+    expect(screen.getByTestId('stytch-widget')).toBeInTheDocument();
+  });
+
+  it('prefers Stytch over the API-key notice when both are enabled', async () => {
+    server.use(
+      http.get('*/api/meta', () =>
+        HttpResponse.json({
+          edition: 'ee',
+          auth_modes: ['stytch', 'apikey'],
+          stytch_public_token: 'pk-test-token',
+        }),
+      ),
+    );
+    renderWithProviders(<LoginForm />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /managed sign-in/i })).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole('heading', { name: /configured API key/i })).not.toBeInTheDocument();
+  });
+
+  it('explains when no interactive auth mode is enabled', async () => {
+    server.use(http.get('*/api/meta', () => HttpResponse.json({ edition: 'oss', auth_modes: [] })));
+    renderWithProviders(<LoginForm />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /sign-in unavailable/i })).toBeInTheDocument(),
+    );
     expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
   });
 });

--- a/frontend/ui/src/features/auth/login-form.tsx
+++ b/frontend/ui/src/features/auth/login-form.tsx
@@ -2,6 +2,7 @@ import { useState, type FormEvent, type ReactNode } from 'react';
 
 import { useAuth } from '@/features/auth';
 
+import { StytchLogin } from './stytch-login';
 import styles from './login-form.module.css';
 
 export interface LoginFormProps {
@@ -11,9 +12,9 @@ export interface LoginFormProps {
 
 /**
  * `/meta`-adaptive, a11y-complete login form. Renders the password form when the
- * deployment enables `password` (or before `/meta` resolves), and otherwise explains
- * the configured non-interactive auth mode (`apikey`) or the future managed sign-in
- * (`stytch`). This is the production replacement for the foundation's placeholder form.
+ * deployment enables `password` (or before `/meta` resolves), the Stytch managed
+ * sign-in widget when `stytch` is enabled (both side by side in mixed mode), and
+ * otherwise explains the configured non-interactive auth mode (`apikey`).
  */
 export function LoginForm({ onSuccess }: LoginFormProps): ReactNode {
   const { meta, login } = useAuth();
@@ -41,7 +42,7 @@ export function LoginForm({ onSuccess }: LoginFormProps): ReactNode {
   }
 
   if (passwordEnabled) {
-    return (
+    const passwordForm = (
       <form
         className={styles.form}
         onSubmit={(event) => void onSubmit(event)}
@@ -88,6 +89,23 @@ export function LoginForm({ onSuccess }: LoginFormProps): ReactNode {
         </button>
       </form>
     );
+
+    if (!stytchEnabled) return passwordForm;
+
+    // Mixed mode: both interactive paths in one layout, separated for clarity.
+    return (
+      <div className={styles.stack}>
+        {passwordForm}
+        <div className={styles.separator} role="separator" aria-orientation="horizontal">
+          <span>or</span>
+        </div>
+        <StytchLogin onSuccess={onSuccess} />
+      </div>
+    );
+  }
+
+  if (stytchEnabled) {
+    return <StytchLogin onSuccess={onSuccess} />;
   }
 
   if (apiKeyEnabled) {
@@ -98,15 +116,6 @@ export function LoginForm({ onSuccess }: LoginFormProps): ReactNode {
           This deployment authenticates with a configured API key — no interactive login is
           required.
         </p>
-      </div>
-    );
-  }
-
-  if (stytchEnabled) {
-    return (
-      <div className={styles.notice} role="status">
-        <h2 className={styles.title}>Managed sign-in</h2>
-        <p className={styles.sub}>Managed sign-in is coming soon.</p>
       </div>
     );
   }

--- a/frontend/ui/src/features/auth/stytch-login.module.css
+++ b/frontend/ui/src/features/auth/stytch-login.module.css
@@ -1,0 +1,28 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.title {
+  font-size: 18px;
+  margin: 0 0 4px;
+  color: var(--ink);
+}
+
+.loading {
+  color: var(--muted);
+  margin: 0;
+}
+
+.error {
+  color: var(--danger);
+  margin: 8px 0 0;
+  font-size: 13px;
+}
+
+.widget {
+  /* The Stytch prebuilt widget mounts here; keep it flush with the panel. */
+  display: flex;
+  flex-direction: column;
+}

--- a/frontend/ui/src/features/auth/stytch-login.test.tsx
+++ b/frontend/ui/src/features/auth/stytch-login.test.tsx
@@ -1,0 +1,229 @@
+import { act, screen, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { db, server } from '@/mocks';
+import { renderWithProviders } from '@/test';
+
+import { StytchLogin } from './stytch-login';
+import { useAuth } from './use-auth';
+
+// --- Stytch SDK stub -------------------------------------------------------------
+// The prebuilt widget is Stytch's code, not ours: the stub captures what our
+// integration hands the SDK (publishable token, config, callbacks) and lets tests
+// drive the auth-complete event without any real Stytch traffic.
+
+interface StubCallbacks {
+  onEvent?: (event: { type: string; data: unknown }) => void;
+  onError?: (error: unknown) => void;
+}
+
+interface StubMountProps {
+  callbacks?: StubCallbacks;
+  config?: { products?: unknown[] };
+}
+
+const stytchStub = vi.hoisted(() => {
+  const state: {
+    callbacks: StubCallbacks | null;
+    tokens: { session_token: string; session_jwt: string } | null;
+    publicTokens: string[];
+  } = { callbacks: null, tokens: null, publicTokens: [] };
+  const mountLogin = vi.fn((props: StubMountProps) => {
+    state.callbacks = props.callbacks ?? null;
+  });
+  return { state, mountLogin };
+});
+
+vi.mock('@stytch/vanilla-js', () => {
+  class StytchUIClient {
+    readonly session = {
+      getTokens: (): { session_token: string; session_jwt: string } | null =>
+        stytchStub.state.tokens,
+    };
+    constructor(publicToken: string) {
+      stytchStub.state.publicTokens.push(publicToken);
+    }
+    mountLogin(props: StubMountProps): void {
+      stytchStub.mountLogin(props);
+    }
+  }
+  return {
+    StytchUIClient,
+    Products: {
+      emailMagicLinks: { id: 'emailMagicLinks', screens: {} },
+      oauth: { id: 'oauth', screens: {} },
+    },
+    StytchEventType: { AuthenticateFlowComplete: 'AUTHENTICATE_FLOW_COMPLETE' },
+  };
+});
+
+// --- helpers ---------------------------------------------------------------------
+
+/** Point `/meta` at a stytch-only EE deployment with the given publishable token. */
+function useStytchMeta(stytchPublicToken: string | null = 'pk-test-token'): void {
+  server.use(
+    http.get('*/api/meta', () =>
+      HttpResponse.json({
+        edition: 'ee',
+        auth_modes: ['stytch'],
+        stytch_public_token: stytchPublicToken,
+      }),
+    ),
+  );
+}
+
+/** Point `/meta` at a stytch-only EE deployment that omits the token field entirely. */
+function useStytchMetaWithoutToken(): void {
+  server.use(
+    http.get('*/api/meta', () => HttpResponse.json({ edition: 'ee', auth_modes: ['stytch'] })),
+  );
+}
+
+/** StytchLogin next to a probe so tests can observe the shared auth state. */
+function Harness({ onSuccess }: { readonly onSuccess?: () => void }): ReactNode {
+  const { status, principal } = useAuth();
+  return (
+    <div>
+      <span data-testid="status">{status}</span>
+      <span data-testid="edition">{principal?.edition ?? 'none'}</span>
+      <StytchLogin onSuccess={onSuccess} />
+    </div>
+  );
+}
+
+function fireAuthComplete(): void {
+  act(() => {
+    stytchStub.state.callbacks?.onEvent?.({ type: 'AUTHENTICATE_FLOW_COMPLETE', data: {} });
+  });
+}
+
+describe('StytchLogin', () => {
+  beforeEach(() => {
+    stytchStub.state.callbacks = null;
+    stytchStub.state.tokens = null;
+    stytchStub.state.publicTokens = [];
+    stytchStub.mountLogin.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('renders an accessible notice when no publishable token is configured', async () => {
+    db.principal = null;
+    useStytchMeta(null);
+    renderWithProviders(<StytchLogin />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/publishable token/i);
+    expect(stytchStub.mountLogin).not.toHaveBeenCalled();
+  });
+
+  it('mounts the prebuilt widget with the token from /meta (magic links + OAuth)', async () => {
+    db.principal = null;
+    useStytchMeta('pk-from-meta');
+    renderWithProviders(<StytchLogin />);
+
+    await waitFor(() => expect(stytchStub.mountLogin).toHaveBeenCalledTimes(1));
+    expect(stytchStub.state.publicTokens).toEqual(['pk-from-meta']);
+    expect(screen.getByRole('heading', { name: /managed sign-in/i })).toBeInTheDocument();
+    expect(screen.getByTestId('stytch-widget')).toBeInTheDocument();
+
+    const props = stytchStub.mountLogin.mock.calls[0]![0];
+    expect(props.config?.products).toHaveLength(2);
+  });
+
+  it('falls back to VITE_STYTCH_PUBLIC_TOKEN when /meta has no token', async () => {
+    db.principal = null;
+    vi.stubEnv('VITE_STYTCH_PUBLIC_TOKEN', 'pk-from-env');
+    useStytchMetaWithoutToken();
+    renderWithProviders(<StytchLogin />);
+
+    await waitFor(() => expect(stytchStub.mountLogin).toHaveBeenCalledTimes(1));
+    expect(stytchStub.state.publicTokens).toEqual(['pk-from-env']);
+  });
+
+  it('exchanges the Stytch session for a LAVS session and updates auth state', async () => {
+    db.principal = null;
+    useStytchMeta();
+    const onSuccess = vi.fn();
+    renderWithProviders(<Harness onSuccess={onSuccess} />);
+
+    await waitFor(() => expect(stytchStub.mountLogin).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByTestId('status')).toHaveTextContent(/^unauthenticated$/),
+    );
+
+    stytchStub.state.tokens = { session_token: 'opaque-token', session_jwt: 'stytch-jwt' };
+    fireAuthComplete();
+
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent(/^authenticated$/));
+    expect(screen.getByTestId('edition')).toHaveTextContent('ee');
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces the API error when the callback exchange is rejected (401)', async () => {
+    db.principal = null;
+    useStytchMeta();
+    const onSuccess = vi.fn();
+    renderWithProviders(<Harness onSuccess={onSuccess} />);
+
+    await waitFor(() => expect(stytchStub.mountLogin).toHaveBeenCalledTimes(1));
+
+    stytchStub.state.tokens = { session_token: 'opaque-token', session_jwt: 'stytch-invalid' };
+    fireAuthComplete();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/stytch session rejected/i);
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(screen.getByTestId('status')).toHaveTextContent(/^unauthenticated$/);
+  });
+
+  it('reports when the widget completes without producing a session token', async () => {
+    db.principal = null;
+    useStytchMeta();
+    renderWithProviders(<StytchLogin />);
+
+    await waitFor(() => expect(stytchStub.mountLogin).toHaveBeenCalledTimes(1));
+
+    stytchStub.state.tokens = null;
+    fireAuthComplete();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/did not produce a session token/i);
+  });
+
+  it('shows an alert when the Stytch SDK reports an error', async () => {
+    db.principal = null;
+    useStytchMeta();
+    renderWithProviders(<StytchLogin />);
+
+    await waitFor(() => expect(stytchStub.mountLogin).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      stytchStub.state.callbacks?.onError?.(new Error('widget exploded'));
+    });
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/managed sign-in failed/i);
+  });
+
+  it('ignores non-authenticate widget events', async () => {
+    db.principal = null;
+    useStytchMeta();
+    renderWithProviders(<Harness />);
+
+    await waitFor(() => expect(stytchStub.mountLogin).toHaveBeenCalledTimes(1));
+
+    stytchStub.state.tokens = { session_token: 'opaque-token', session_jwt: 'stytch-jwt' };
+    act(() => {
+      stytchStub.state.callbacks?.onEvent?.({ type: 'MAGIC_LINK_LOGIN_OR_CREATE', data: {} });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('status')).toHaveTextContent(/^unauthenticated$/),
+    );
+  });
+});

--- a/frontend/ui/src/features/auth/stytch-login.tsx
+++ b/frontend/ui/src/features/auth/stytch-login.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+
+import type { Meta } from '@/types';
+
+import { useAuth } from './use-auth';
+import styles from './stytch-login.module.css';
+
+// Type-only namespace import: erased at compile time, so the SDK itself is still
+// loaded lazily via dynamic import() below.
+import type * as StytchSdk from '@stytch/vanilla-js';
+
+export interface StytchLoginProps {
+  /** Invoked after the Stytch session is exchanged for a LAVS session. */
+  readonly onSuccess?: () => void;
+}
+
+/** DOM id the Stytch prebuilt widget mounts into (one login screen per page). */
+const STYTCH_WIDGET_ID = 'stytch-login-widget';
+
+type StytchModule = typeof StytchSdk;
+
+/**
+ * Publishable token sourcing: prefer the deploy config (`/meta`), fall back to the
+ * build-time `VITE_STYTCH_PUBLIC_TOKEN`. Empty strings count as unconfigured.
+ */
+function resolvePublicToken(meta: Meta): string | null {
+  const token = meta.stytch_public_token ?? import.meta.env.VITE_STYTCH_PUBLIC_TOKEN ?? null;
+  return token !== null && token !== '' ? token : null;
+}
+
+/**
+ * EE managed sign-in. Lazy-loads `@stytch/vanilla-js` (the SDK never enters the main
+ * bundle for OSS deployments) and mounts Stytch's prebuilt login widget configured for
+ * email magic links + OAuth. When the widget completes an auth flow, the Stytch session
+ * token is exchanged at `POST /auth/stytch/callback` via the auth context, which sets the
+ * HttpOnly `lavs_session` cookie and promotes the returned principal into app state —
+ * exactly mirroring the password `login()` flow.
+ */
+export function StytchLogin({ onSuccess }: StytchLoginProps): ReactNode {
+  const { meta, completeStytchLogin } = useAuth();
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Latest-ref pattern: the widget mounts once per token; callbacks stay fresh without
+  // remounting Stytch's DOM on every provider render.
+  const completeStytchLoginRef = useRef(completeStytchLogin);
+  const onSuccessRef = useRef(onSuccess);
+  useEffect(() => {
+    completeStytchLoginRef.current = completeStytchLogin;
+    onSuccessRef.current = onSuccess;
+  });
+
+  const publicToken = meta ? resolvePublicToken(meta) : null;
+
+  useEffect(() => {
+    if (!publicToken) return undefined;
+    let cancelled = false;
+    let exchanging = false;
+
+    async function mountWidget(): Promise<void> {
+      let stytch: StytchModule;
+      try {
+        stytch = await import('@stytch/vanilla-js');
+      } catch {
+        if (!cancelled) {
+          setError('Managed sign-in failed to load. Reload the page to try again.');
+        }
+        return;
+      }
+      if (cancelled || !publicToken) return;
+
+      const client = new stytch.StytchUIClient(publicToken);
+
+      async function exchange(): Promise<void> {
+        if (exchanging) return;
+        exchanging = true;
+        setError(null);
+        const tokens = client.session.getTokens();
+        // Prefer the JWT (what the backend verifies); fall back to the opaque token.
+        const sessionToken = tokens?.session_jwt ?? tokens?.session_token ?? null;
+        if (!sessionToken) {
+          exchanging = false;
+          setError('Managed sign-in did not produce a session token. Please try again.');
+          return;
+        }
+        const result = await completeStytchLoginRef.current(sessionToken);
+        exchanging = false;
+        if (result.ok) {
+          onSuccessRef.current?.();
+        } else {
+          setError(result.error.message);
+        }
+      }
+
+      // Redirect magic links / OAuth back to this page; the remounted widget then
+      // authenticates the token from the URL and fires AuthenticateFlowComplete.
+      const redirectUrl = window.location.href;
+      client.mountLogin({
+        client,
+        elementId: `#${STYTCH_WIDGET_ID}`,
+        config: {
+          products: [stytch.Products.emailMagicLinks, stytch.Products.oauth],
+          emailMagicLinksOptions: {
+            loginRedirectURL: redirectUrl,
+            signupRedirectURL: redirectUrl,
+          },
+          oauthOptions: {
+            // Fixed product decision (P6 plan, G-P6e): consumer Stytch with magic links +
+            // Google/GitHub OAuth. Deployments must enable these providers on their Stytch
+            // project; making the list deploy-configurable is deliberately deferred.
+            providers: [{ type: 'google' }, { type: 'github' }],
+            loginRedirectURL: redirectUrl,
+            signupRedirectURL: redirectUrl,
+          },
+        },
+        callbacks: {
+          onEvent: (event) => {
+            if (event.type === stytch.StytchEventType.AuthenticateFlowComplete) {
+              void exchange();
+            }
+          },
+          onError: () => {
+            setError('Managed sign-in failed. Please try again.');
+          },
+        },
+      });
+      setReady(true);
+    }
+
+    void mountWidget();
+    return (): void => {
+      cancelled = true;
+    };
+  }, [publicToken]);
+
+  if (!meta) {
+    return (
+      <div className={styles.container}>
+        <p className={styles.loading} role="status">
+          Loading sign-in configuration…
+        </p>
+      </div>
+    );
+  }
+
+  if (!publicToken) {
+    return (
+      <div className={styles.container}>
+        <h2 className={styles.title}>Managed sign-in</h2>
+        <p className={styles.error} role="alert">
+          Managed sign-in is enabled, but no Stytch publishable token is configured. Set it in the
+          deployment config (or via VITE_STYTCH_PUBLIC_TOKEN) and reload.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <section className={styles.container} aria-labelledby="stytch-login-title">
+      <h2 id="stytch-login-title" className={styles.title}>
+        Managed sign-in
+      </h2>
+      {!ready && !error ? (
+        <p className={styles.loading} role="status">
+          Loading managed sign-in…
+        </p>
+      ) : null}
+      {error ? (
+        <p className={styles.error} role="alert">
+          {error}
+        </p>
+      ) : null}
+      <div id={STYTCH_WIDGET_ID} className={styles.widget} data-testid="stytch-widget" />
+    </section>
+  );
+}

--- a/frontend/ui/src/mocks/handlers.ts
+++ b/frontend/ui/src/mocks/handlers.ts
@@ -47,6 +47,24 @@ export const handlers: HttpHandler[] = [
     return new HttpResponse(null, { status: 204 });
   }),
 
+  // EE: exchange a Stytch session token/JWT for a LAVS session cookie + principal.
+  http.post(`${BASE}/auth/stytch/callback`, async ({ request }) => {
+    const body = (await request.json()) as { stytch_token?: string };
+    if (!body.stytch_token) {
+      return errorResponse(422, 'validation_error', 'stytch_token is required');
+    }
+    if (body.stytch_token === 'stytch-invalid') {
+      return errorResponse(401, 'unauthorized', 'Stytch session rejected');
+    }
+    db.principal = {
+      kind: 'user',
+      id: 'user-stytch-1',
+      email: 'astronomer@snoodleboot.com',
+      edition: 'ee',
+    };
+    return HttpResponse.json(db.principal);
+  }),
+
   // --- products / timeline ---
   http.get(`${BASE}/products`, () => HttpResponse.json([db.product])),
 

--- a/frontend/ui/src/types/domain.ts
+++ b/frontend/ui/src/types/domain.ts
@@ -78,4 +78,6 @@ export interface Principal {
 export interface Meta {
   readonly edition: Edition;
   readonly auth_modes: readonly AuthMode[];
+  /** EE only: Stytch publishable token for the managed sign-in widget (absent on OSS). */
+  readonly stytch_public_token?: string | null;
 }

--- a/frontend/ui/src/vite-env.d.ts
+++ b/frontend/ui/src/vite-env.d.ts
@@ -2,6 +2,8 @@
 
 interface ImportMetaEnv {
   readonly VITE_LAVS_API_URL?: string;
+  /** Build-time fallback for the Stytch publishable token when `/meta` does not supply one. */
+  readonly VITE_STYTCH_PUBLIC_TOKEN?: string;
 }
 
 interface ImportMeta {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pydantic>=2.12.5",
     "python-ulid>=3.1.0",
     "pyyaml>=6.0.0",
+    "stytch>=15.3.0",
     "uvicorn>=0.40.0",
 ]
 

--- a/tests/acceptance/test_auth_stytch.py
+++ b/tests/acceptance/test_auth_stytch.py
@@ -1,0 +1,471 @@
+"""Acceptance: EE Stytch callback, session round-trip, and /meta (API_CONTRACT §1–2).
+
+Drives the REAL ``POST /auth/stytch/callback`` against an EE-configured app
+whose Stytch verification seam is a fake installed on
+``app.state.stytch_verifier`` — no network is ever touched. The happy path
+proves a verifying token mints the same hardened ``lavs_session`` cookie as
+``/auth/login`` and that the cookie then authenticates ``GET /auth/me`` and a
+protected resource route (stytch-only deployments still resolve the session
+cookie). Negatives pin the fail-closed posture: an expired/garbage token, a
+disabled account, and a callback on a non-EE deployment all answer the same
+generic 401 envelope (no enumeration, no "disabled route" fingerprint). The
+``/meta`` matrix asserts EE+stytch advertises the mode and the publishable
+public token while the OSS response stays byte-compatible.
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import duckdb
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth.stytch.stytch_verification import StytchVerification
+from app.auth.stytch.stytch_verifier import StytchVerifier
+from app.auth.users.user_repository import UserRepository
+from tests.acceptance._auth_support import (
+    SESSION_COOKIE_NAME,
+    assert_error_envelope,
+    auth_test_client,
+    unique_email,
+)
+
+VALID_TOKEN = "WJtR5BCy38Szd5AfoDpf0iqFKEt4EE5JhjlWUY7l3FtY"
+STYTCH_USER_ID = "user-test-16d9ba61-97a1-4ba4-9720-b03761dc50c6"
+PUBLIC_TOKEN = "public-token-test-acceptance"
+
+
+class FakeStytchVerifier(StytchVerifier):
+    """A verifier accepting a fixed token map — the injected SDK stand-in."""
+
+    def __init__(self, known: dict[str, StytchVerification]) -> None:
+        """Initialise the fake.
+
+        Args:
+            known: Map of accepted raw tokens to the identity they verify as.
+        """
+        self._known = known
+
+    async def verify(self, token: str) -> StytchVerification | None:
+        """Resolve a token against the fixed map (None when unknown)."""
+        return self._known.get(token)
+
+
+@contextmanager
+def stytch_test_client(
+    monkeypatch,
+    *,
+    edition: str | None = "ee",
+    modes: str = "stytch",
+    public_token: str | None = PUBLIC_TOKEN,
+    allowed_domains: str | None = None,
+) -> Iterator[TestClient]:
+    """Yield a lifespan-active client configured for the Stytch (EE) mode.
+
+    The ``LAVS_*`` environment is set before the client is constructed so the
+    lifespan reads the intended edition and modes. No real Stytch credentials
+    are configured — tests install a :class:`FakeStytchVerifier` on
+    ``app.state.stytch_verifier`` before exercising the callback.
+
+    Args:
+        monkeypatch: The pytest ``monkeypatch`` fixture (auto-undone on teardown).
+        edition: The ``LAVS_EDITION`` value (``None`` leaves it unset — OSS).
+        modes: The ``LAVS_AUTH_MODES`` comma list.
+        public_token: The publishable token to expose, or ``None`` for unset.
+        allowed_domains: The ``LAVS_ALLOWED_EMAIL_DOMAINS`` comma list, or
+            ``None`` for unset (allow all).
+
+    Yields:
+        A :class:`~fastapi.testclient.TestClient` whose lifespan has run.
+    """
+    monkeypatch.setenv("LAVS_AUTH_MODES", modes)
+    if allowed_domains is not None:
+        monkeypatch.setenv("LAVS_ALLOWED_EMAIL_DOMAINS", allowed_domains)
+    else:
+        monkeypatch.delenv("LAVS_ALLOWED_EMAIL_DOMAINS", raising=False)
+    if edition is not None:
+        monkeypatch.setenv("LAVS_EDITION", edition)
+    else:
+        monkeypatch.delenv("LAVS_EDITION", raising=False)
+    if public_token is not None:
+        monkeypatch.setenv("LAVS_STYTCH_PUBLIC_TOKEN", public_token)
+    else:
+        monkeypatch.delenv("LAVS_STYTCH_PUBLIC_TOKEN", raising=False)
+    monkeypatch.delenv("LAVS_API_KEY", raising=False)
+    monkeypatch.delenv("LAVS_STYTCH_PROJECT_ID", raising=False)
+    monkeypatch.delenv("LAVS_STYTCH_SECRET", raising=False)
+
+    from app.main import app
+
+    # https base_url so the Secure lavs_session cookie rides the client's
+    # cookie jar (a test-transport constraint, not app behaviour).
+    with TestClient(app, base_url="https://testserver", raise_server_exceptions=False) as client:
+        yield client
+
+
+def _install_fake_verifier(client: TestClient, email: str) -> None:
+    """Install a fake verifier accepting ``VALID_TOKEN`` for ``email``."""
+    client.app.state.stytch_verifier = FakeStytchVerifier(
+        {VALID_TOKEN: StytchVerification(user_id=STYTCH_USER_ID, email=email)}
+    )
+
+
+def _callback(client: TestClient, token: str):
+    """POST ``/auth/stytch/callback`` and return the raw response."""
+    return client.post("/auth/stytch/callback", json={"stytch_token": token})
+
+
+@pytest.fixture
+def stytch_client(monkeypatch, test_db: str):
+    """A lifespan-active EE client with stytch-only auth configured."""
+    with stytch_test_client(monkeypatch) as client:
+        yield client
+
+
+def _session_set_cookie(response) -> str:
+    """Return the ``Set-Cookie`` header line that sets the session cookie."""
+    cookie_headers = response.headers.get_list("set-cookie")
+    for header in cookie_headers:
+        if header.startswith(f"{SESSION_COOKIE_NAME}="):
+            return header
+    raise AssertionError(
+        f"no {SESSION_COOKIE_NAME} Set-Cookie header on callback response; got {cookie_headers}"
+    )
+
+
+class TestStytchCallback:
+    """The callback exchanges a verified token for the normal LAVS session."""
+
+    def test_valid_token_sets_the_hardened_session_cookie(self, stytch_client: TestClient) -> None:
+        """A verifying token returns 200, the user body, and the hardened cookie."""
+        # Arrange
+        email = unique_email()
+        _install_fake_verifier(stytch_client, email)
+
+        # Act
+        response = _callback(stytch_client, VALID_TOKEN)
+
+        # Assert — same cookie contract as /auth/login
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["email"] == email
+        assert body["status"] == "active"
+        set_cookie = _session_set_cookie(response)
+        assert "httponly" in set_cookie.lower(), set_cookie
+        assert "samesite=lax" in set_cookie.lower(), set_cookie
+        assert "secure" in set_cookie.lower(), set_cookie
+        assert "path=/" in set_cookie.lower(), set_cookie
+
+    def test_callback_session_authenticates_auth_me(self, stytch_client: TestClient) -> None:
+        """The minted session cookie round-trips through ``GET /auth/me``."""
+        # Arrange
+        email = unique_email()
+        _install_fake_verifier(stytch_client, email)
+        callback_response = _callback(stytch_client, VALID_TOKEN)
+        assert callback_response.status_code == 200, callback_response.text
+
+        # Act — the client's cookie jar replays the session cookie automatically
+        response = stytch_client.get("/auth/me")
+
+        # Assert
+        assert response.status_code == 200, response.text
+        assert response.json()["email"] == email
+
+    def test_callback_session_authenticates_resource_routes(
+        self, stytch_client: TestClient
+    ) -> None:
+        """Stytch-only deployments still resolve the session cookie on resources."""
+        # Arrange — before any credential the deployment fails closed
+        unauthenticated = stytch_client.get("/products")
+        assert unauthenticated.status_code == 401, unauthenticated.text
+        email = unique_email()
+        _install_fake_verifier(stytch_client, email)
+        assert _callback(stytch_client, VALID_TOKEN).status_code == 200
+
+        # Act
+        response = stytch_client.get("/products")
+
+        # Assert
+        assert response.status_code == 200, response.text
+
+    def test_repeat_callback_reuses_the_same_user(self, stytch_client: TestClient) -> None:
+        """A second callback for the same email maps to the same user row."""
+        # Arrange
+        email = unique_email()
+        _install_fake_verifier(stytch_client, email)
+        first = _callback(stytch_client, VALID_TOKEN)
+        assert first.status_code == 200, first.text
+
+        # Act
+        second = _callback(stytch_client, VALID_TOKEN)
+
+        # Assert — idempotent upsert: one account, stable id
+        assert second.status_code == 200, second.text
+        assert second.json()["id"] == first.json()["id"]
+
+    def test_pending_user_is_activated_by_stytch_verification(
+        self, monkeypatch, test_db: str
+    ) -> None:
+        """A pending password sign-up becomes active after Stytch verifies the email."""
+        # Arrange — password + stytch both enabled; user signs up but never verifies
+        with stytch_test_client(monkeypatch, modes="password,stytch") as client:
+            email = unique_email()
+            signup_response = client.post(
+                "/auth/signup", json={"email": email, "password": "Acceptance-Pass-123!"}
+            )
+            assert signup_response.status_code == 202, signup_response.text
+            _install_fake_verifier(client, email)
+
+            # Act — Stytch has verified the same email
+            response = _callback(client, VALID_TOKEN)
+
+            # Assert — the account is activated, not duplicated
+            assert response.status_code == 200, response.text
+            assert response.json()["status"] == "active"
+            me_response = client.get("/auth/me")
+            assert me_response.status_code == 200, me_response.text
+            assert me_response.json()["status"] == "active"
+
+    def test_garbage_token_returns_generic_401(self, stytch_client: TestClient) -> None:
+        """A token the verifier rejects answers the single generic 401."""
+        # Arrange
+        _install_fake_verifier(stytch_client, unique_email())
+
+        # Act
+        response = _callback(stytch_client, "utterly-garbage-token")
+
+        # Assert
+        assert response.status_code == 401, response.text
+        assert_error_envelope(response.json(), "unauthorized")
+
+    def test_expired_token_is_indistinguishable_from_garbage(
+        self, stytch_client: TestClient
+    ) -> None:
+        """An expired (formerly valid) token gets the identical 401 shape."""
+        # Arrange — a verifier that no longer accepts any token (all expired)
+        stytch_client.app.state.stytch_verifier = FakeStytchVerifier({})
+
+        # Act
+        response = _callback(stytch_client, VALID_TOKEN)
+
+        # Assert
+        assert response.status_code == 401, response.text
+        assert_error_envelope(response.json(), "unauthorized")
+
+    def test_disabled_account_returns_generic_401(self, stytch_client: TestClient) -> None:
+        """A disabled user cannot re-enter through Stytch — same generic 401."""
+        # Arrange — create the account via a first callback, then disable it
+        email = unique_email()
+        _install_fake_verifier(stytch_client, email)
+        first = _callback(stytch_client, VALID_TOKEN)
+        assert first.status_code == 200, first.text
+        connection = stytch_client.app.state.db_connection
+        connection.execute("UPDATE users SET status = ? WHERE email = ?", ["disabled", email])
+
+        # Act
+        response = _callback(stytch_client, VALID_TOKEN)
+
+        # Assert
+        assert response.status_code == 401, response.text
+        assert_error_envelope(response.json(), "unauthorized")
+
+    def test_unverified_only_email_returns_generic_401(self, stytch_client: TestClient) -> None:
+        """An identity with no **verified** email is refused — no takeover lane."""
+        # Arrange — the verifier resolved an identity but surfaced no verified
+        # email (StytchVerification.email is None in that case)
+        stytch_client.app.state.stytch_verifier = FakeStytchVerifier(
+            {VALID_TOKEN: StytchVerification(user_id=STYTCH_USER_ID, email=None)}
+        )
+
+        # Act
+        response = _callback(stytch_client, VALID_TOKEN)
+
+        # Assert
+        assert response.status_code == 401, response.text
+        assert_error_envelope(response.json(), "unauthorized")
+
+    def test_concurrent_first_sight_race_adopts_the_winning_row(
+        self, stytch_client: TestClient, monkeypatch
+    ) -> None:
+        """A lost insert race on the unique email maps to the winner's row.
+
+        Simulates two first-sight callbacks racing: our read saw no row, the
+        concurrent request inserted one, and our insert hits the unique-email
+        constraint. The callback must adopt the existing row instead of
+        surfacing a duplicate-key 500.
+        """
+        # Arrange — create_user performs the real insert (the concurrent
+        # winner) and then raises the constraint violation our own insert hits
+        email = unique_email()
+        _install_fake_verifier(stytch_client, email)
+        original_create = UserRepository.create_user
+
+        # design-decision-override: the closure must capture original_create to
+        # both perform the winner's insert and raise the loser's violation.
+        async def racing_create(self, conn, **kwargs):
+            await original_create(self, conn, **kwargs)
+            raise duckdb.ConstraintException(
+                "Duplicate key violates unique constraint on users.email"
+            )
+
+        monkeypatch.setattr(UserRepository, "create_user", racing_create)
+
+        # Act
+        response = _callback(stytch_client, VALID_TOKEN)
+
+        # Assert — 200 with the row the "winner" created
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["email"] == email
+        assert body["status"] == "active"
+        row = stytch_client.app.state.db_connection.execute(
+            "SELECT id FROM users WHERE email = ?", [email]
+        ).fetchone()
+        assert row is not None
+        assert body["id"] == str(row[0])
+
+    def test_missing_token_field_is_a_422(self, stytch_client: TestClient) -> None:
+        """An omitted ``stytch_token`` is malformed input, not bad credentials."""
+        # Act
+        response = stytch_client.post("/auth/stytch/callback", json={})
+
+        # Assert
+        assert response.status_code == 422, response.text
+
+
+class TestStytchDomainAllowList:
+    """The email-domain allow-list holds on the Stytch lane (generic 401)."""
+
+    def test_first_sight_outside_allowlist_returns_generic_401(
+        self, monkeypatch, test_db: str
+    ) -> None:
+        """A first-sight verified email outside the allow-list is refused."""
+        # Arrange — allow-list pins example.com; Stytch verifies an outsider
+        with stytch_test_client(monkeypatch, allowed_domains="example.com") as client:
+            outsider = unique_email(domain="not-allowed.test")
+            _install_fake_verifier(client, outsider)
+
+            # Act
+            response = _callback(client, VALID_TOKEN)
+
+            # Assert — generic 401 (not signup's 403: no allow-list fingerprint)
+            assert response.status_code == 401, response.text
+            assert_error_envelope(response.json(), "unauthorized")
+            row = client.app.state.db_connection.execute(
+                "SELECT id FROM users WHERE email = ?", [outsider]
+            ).fetchone()
+            assert row is None, "no user row may be created for a disallowed domain"
+
+    def test_existing_user_outside_tightened_allowlist_returns_generic_401(
+        self, monkeypatch, test_db: str
+    ) -> None:
+        """Defense in depth: a tightened allow-list also locks out mapped users."""
+        # Arrange — the user maps in while their domain is allowed…
+        email = unique_email()
+        with stytch_test_client(monkeypatch) as client:
+            _install_fake_verifier(client, email)
+            assert _callback(client, VALID_TOKEN).status_code == 200
+
+        # …then the operator tightens the allow-list to another domain
+        with stytch_test_client(monkeypatch, allowed_domains="other-corp.test") as client:
+            _install_fake_verifier(client, email)
+
+            # Act
+            response = _callback(client, VALID_TOKEN)
+
+            # Assert — the existing mapping does not grandfather them in
+            assert response.status_code == 401, response.text
+            assert_error_envelope(response.json(), "unauthorized")
+
+    def test_allowlisted_domain_still_authenticates(self, monkeypatch, test_db: str) -> None:
+        """A verified email inside the allow-list proceeds normally."""
+        # Arrange
+        with stytch_test_client(monkeypatch, allowed_domains="example.com") as client:
+            email = unique_email()
+            _install_fake_verifier(client, email)
+
+            # Act
+            response = _callback(client, VALID_TOKEN)
+
+            # Assert
+            assert response.status_code == 200, response.text
+            assert response.json()["email"] == email
+
+
+class TestStytchDisabledOnOss:
+    """Without EE the stytch mode — and its callback — stay dark."""
+
+    def test_callback_on_oss_returns_generic_401(self, monkeypatch, test_db: str) -> None:
+        """On OSS the callback answers the same generic 401 as a bad credential."""
+        # Arrange — stytch listed in modes but no EE edition: token is ignored
+        with stytch_test_client(monkeypatch, edition=None) as client:
+            _install_fake_verifier(client, unique_email())
+
+            # Act — even a token the verifier would accept is refused
+            response = _callback(client, VALID_TOKEN)
+
+            # Assert
+            assert response.status_code == 401, response.text
+            assert_error_envelope(response.json(), "unauthorized")
+
+    def test_meta_on_oss_does_not_advertise_stytch(self, monkeypatch, test_db: str) -> None:
+        """OSS ``/meta`` never lists stytch nor leaks the public token."""
+        # Arrange
+        with stytch_test_client(monkeypatch, edition=None) as client:
+            # Act
+            response = client.get("/meta")
+
+            # Assert
+            assert response.status_code == 200, response.text
+            body = response.json()
+            assert body["edition"] == "oss"
+            assert "stytch" not in body["auth_modes"]
+            assert "stytch_public_token" not in body
+
+
+class TestMetaOnEe:
+    """EE ``/meta`` advertises the stytch mode and the publishable token."""
+
+    def test_meta_reports_ee_stytch_and_public_token(self, stytch_client: TestClient) -> None:
+        """``GET /meta`` returns edition ee, the stytch mode, and the token."""
+        # Act
+        response = stytch_client.get("/meta")
+
+        # Assert
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["edition"] == "ee"
+        assert "stytch" in body["auth_modes"]
+        assert body["stytch_public_token"] == PUBLIC_TOKEN
+
+    def test_meta_without_public_token_omits_the_key(self, monkeypatch, test_db: str) -> None:
+        """An EE deployment with no publishable token configured omits the key."""
+        # Arrange
+        with stytch_test_client(monkeypatch, public_token=None) as client:
+            # Act
+            response = client.get("/meta")
+
+            # Assert
+            assert response.status_code == 200, response.text
+            body = response.json()
+            assert body["edition"] == "ee"
+            assert "stytch_public_token" not in body
+
+
+class TestOssMetaUnchanged:
+    """The pre-EE OSS ``/meta`` behaviour is untouched (backward-compatible)."""
+
+    def test_password_apikey_meta_shape_is_stable(self, monkeypatch, test_db: str) -> None:
+        """The OSS password/apikey deployment reports the same modes as before."""
+        # Arrange
+        with auth_test_client(monkeypatch) as client:
+            # Act
+            response = client.get("/meta")
+
+            # Assert
+            assert response.status_code == 200, response.text
+            body = response.json()
+            assert body["edition"] == "oss"
+            assert set(body["auth_modes"]) == {"password", "apikey"}
+            # Byte-compatible with the pre-EE body: the key is absent, not null
+            assert "stytch_public_token" not in body

--- a/tests/unit/auth/providers/test_stytch_provider.py
+++ b/tests/unit/auth/providers/test_stytch_provider.py
@@ -1,0 +1,223 @@
+"""Unit tests for :class:`StytchProvider`."""
+
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+
+from fastapi import Request
+
+from app.auth.principal_kind import PrincipalKind
+from app.auth.providers.stytch_provider import StytchProvider
+from app.auth.stytch.stytch_verification import StytchVerification
+from app.auth.stytch.stytch_verifier import StytchVerifier
+from app.auth.users.user_repository import UserRepository
+from app.connections.db_session import DbSession
+
+
+class FakeStytchVerifier(StytchVerifier):
+    """A verifier resolving a fixed token map — no SDK, no network."""
+
+    def __init__(self, known: dict[str, StytchVerification]) -> None:
+        """Initialise the fake.
+
+        Args:
+            known: Map of accepted raw tokens to the identity they verify as.
+        """
+        self._known = known
+
+    async def verify(self, token: str) -> StytchVerification | None:
+        """Resolve a token against the fixed map (None when unknown)."""
+        return self._known.get(token)
+
+
+class FakeUserRepository(UserRepository):
+    """A users store answering ``get_user_by_email`` from a fixed row map."""
+
+    def __init__(self, rows_by_email: dict[str, tuple[object, ...]]) -> None:
+        """Initialise the fake.
+
+        Args:
+            rows_by_email: Map of email to the raw users row it resolves to.
+        """
+        self._rows_by_email = rows_by_email
+
+    async def get_user_by_email(self, conn: DbSession, email: str) -> tuple[object, ...] | None:
+        """Resolve an email against the fixed map (None when unmapped)."""
+        return self._rows_by_email.get(email)
+
+
+def _user_row(user_id: str, email: str, status: str) -> tuple[object, ...]:
+    """Build a raw users row ``(id, email, password_hash, status, edition, created_at)``."""
+    return (user_id, email, "argon2-hash-unused", status, "ee", None)
+
+
+def _request(cookies: dict[str, str], db_connection: object = "live-db-session") -> Request:
+    """Build a request carrying the given cookies and app-state db connection.
+
+    Args:
+        cookies: Cookie name/value pairs to present.
+        db_connection: The value exposed as ``app.state.db_connection``
+            (``None`` models a deployment without a live database).
+
+    Returns:
+        A request carrying the cookies and state.
+    """
+    headers: list[tuple[bytes, bytes]] = []
+    if cookies:
+        cookie_line = "; ".join(f"{name}={value}" for name, value in cookies.items())
+        headers.append((b"cookie", cookie_line.encode()))
+    app = SimpleNamespace(state=SimpleNamespace(db_connection=db_connection))
+    scope = {"type": "http", "method": "GET", "path": "/", "headers": headers, "app": app}
+    return Request(scope)
+
+
+class TestStytchProvider(IsolatedAsyncioTestCase):
+    """Stytch-cookie authentication resolves the mapped, active LAVS user."""
+
+    def setUp(self) -> None:
+        """Build a provider whose verified email maps to an active LAVS user."""
+        self._verification = StytchVerification(
+            user_id="user-test-00000000-0000-0000-0000-000000000001",
+            email="Engineer@Example.com",
+        )
+        self._lavs_user_id = "01LAVSUSERID0000000000000A"
+        self._provider = StytchProvider(
+            edition="ee",
+            verifier=FakeStytchVerifier({"good-token": self._verification}),
+            user_repository=FakeUserRepository(
+                {
+                    "engineer@example.com": _user_row(
+                        self._lavs_user_id, "engineer@example.com", "active"
+                    )
+                }
+            ),
+        )
+
+    async def test_valid_session_jwt_cookie_returns_lavs_user_principal(self) -> None:
+        """A verifying cookie mints a principal carrying the **LAVS** identity.
+
+        The verified email is normalized (trim/lower) before the lookup, and
+        the principal carries the LAVS user id and row email — never the raw
+        Stytch id, so ``/auth/me`` reflects the real account row.
+        """
+        # Arrange
+        request = _request({"stytch_session_jwt": "good-token"})
+
+        # Act
+        principal = await self._provider.authenticate(request)
+
+        # Assert
+        assert principal is not None
+        assert principal.kind is PrincipalKind.USER
+        assert principal.id == self._lavs_user_id
+        assert principal.email == "engineer@example.com"
+        assert principal.edition == "ee"
+
+    async def test_session_token_cookie_is_the_fallback(self) -> None:
+        """Without a JWT cookie the ``stytch_session`` cookie is verified."""
+        # Arrange
+        request = _request({"stytch_session": "good-token"})
+
+        # Act
+        principal = await self._provider.authenticate(request)
+
+        # Assert
+        assert principal is not None
+        assert principal.id == self._lavs_user_id
+
+    async def test_no_stytch_cookie_returns_none(self) -> None:
+        """A request with no Stytch cookie is not-me — None, never a raise."""
+        # Arrange
+        request = _request({"lavs_session": "some-other-cookie"})
+
+        # Act / Assert
+        assert await self._provider.authenticate(request) is None
+
+    async def test_empty_cookie_value_returns_none(self) -> None:
+        """An empty Stytch cookie value authenticates nobody."""
+        # Arrange
+        request = _request({"stytch_session_jwt": ""})
+
+        # Act / Assert
+        assert await self._provider.authenticate(request) is None
+
+    async def test_invalid_token_returns_none(self) -> None:
+        """A token the verifier rejects resolves to None (not an exception)."""
+        # Arrange
+        request = _request({"stytch_session_jwt": "expired-or-garbage"})
+
+        # Act / Assert
+        assert await self._provider.authenticate(request) is None
+
+    async def test_unmapped_stytch_user_returns_none(self) -> None:
+        """A verified identity with no LAVS user row authenticates nobody."""
+        # Arrange
+        provider = StytchProvider(
+            edition="ee",
+            verifier=FakeStytchVerifier({"good-token": self._verification}),
+            user_repository=FakeUserRepository({}),
+        )
+        request = _request({"stytch_session_jwt": "good-token"})
+
+        # Act / Assert
+        assert await provider.authenticate(request) is None
+
+    async def test_disabled_lavs_user_returns_none(self) -> None:
+        """A disabled LAVS account cannot bypass its disablement via Stytch."""
+        # Arrange
+        provider = StytchProvider(
+            edition="ee",
+            verifier=FakeStytchVerifier({"good-token": self._verification}),
+            user_repository=FakeUserRepository(
+                {
+                    "engineer@example.com": _user_row(
+                        self._lavs_user_id, "engineer@example.com", "disabled"
+                    )
+                }
+            ),
+        )
+        request = _request({"stytch_session_jwt": "good-token"})
+
+        # Act / Assert
+        assert await provider.authenticate(request) is None
+
+    async def test_pending_lavs_user_returns_none(self) -> None:
+        """A not-yet-active (pending) LAVS account authenticates nobody."""
+        # Arrange
+        provider = StytchProvider(
+            edition="ee",
+            verifier=FakeStytchVerifier({"good-token": self._verification}),
+            user_repository=FakeUserRepository(
+                {
+                    "engineer@example.com": _user_row(
+                        self._lavs_user_id, "engineer@example.com", "pending"
+                    )
+                }
+            ),
+        )
+        request = _request({"stytch_session_jwt": "good-token"})
+
+        # Act / Assert
+        assert await provider.authenticate(request) is None
+
+    async def test_verification_without_email_returns_none(self) -> None:
+        """An identity with no verified email fails closed — no principal."""
+        # Arrange
+        provider = StytchProvider(
+            edition="ee",
+            verifier=FakeStytchVerifier(
+                {"no-email-token": StytchVerification(user_id="user-test-2", email=None)}
+            ),
+            user_repository=FakeUserRepository({}),
+        )
+        request = _request({"stytch_session": "no-email-token"})
+
+        # Act / Assert
+        assert await provider.authenticate(request) is None
+
+    async def test_no_database_connection_returns_none(self) -> None:
+        """Without a live database the mapping cannot be checked — fail closed."""
+        # Arrange
+        request = _request({"stytch_session_jwt": "good-token"}, db_connection=None)
+
+        # Act / Assert
+        assert await self._provider.authenticate(request) is None

--- a/tests/unit/auth/stytch/test_stytch_sdk_verifier.py
+++ b/tests/unit/auth/stytch/test_stytch_sdk_verifier.py
@@ -1,0 +1,218 @@
+"""Unit tests for :class:`StytchSdkVerifier` over a fake SDK client (no network)."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+
+import pytest
+from stytch.core.response_base import StytchError, StytchErrorDetails
+
+from app.auth.auth_settings import AuthSettings
+from app.auth.stytch.stytch_sdk_verifier import StytchSdkVerifier
+
+
+def _stytch_error() -> StytchError:
+    """Build a realistic SDK error (what an invalid/expired session raises)."""
+    return StytchError(
+        StytchErrorDetails(
+            status_code=401,
+            request_id="request-id-test",
+            error_type="session_not_found",
+            error_message="Session expired or not found.",
+            error_url="https://stytch.com/docs/api/errors/401",
+        )
+    )
+
+
+class FakeSessions:
+    """Stand-in for ``client.sessions`` recording the authenticate call."""
+
+    def __init__(self, response: object = None, error: Exception | None = None) -> None:
+        """Initialise the fake.
+
+        Args:
+            response: The response to return on success.
+            error: When set, the exception raised instead of responding.
+        """
+        self._response = response
+        self._error = error
+        self.calls: list[dict[str, str | None]] = []
+
+    async def authenticate_async(
+        self, session_token: str | None = None, session_jwt: str | None = None
+    ) -> object:
+        """Record the call and answer with the configured response or error."""
+        self.calls.append({"session_token": session_token, "session_jwt": session_jwt})
+        if self._error is not None:
+            raise self._error
+        return self._response
+
+
+def _fake_client(sessions: FakeSessions) -> object:
+    """Wrap a fake sessions API in a client-shaped object."""
+    return SimpleNamespace(sessions=sessions)
+
+
+def _sdk_response(user_id: str, emails: list[tuple[str, bool]]) -> object:
+    """Build a response shaped like the SDK's ``AuthenticateResponse``.
+
+    Args:
+        user_id: The Stytch user id.
+        emails: ``(address, verified)`` pairs in SDK order.
+
+    Returns:
+        An object with the ``.user.user_id`` / ``.user.emails`` surface.
+    """
+    email_objects = [
+        SimpleNamespace(email=address, verified=verified) for address, verified in emails
+    ]
+    return SimpleNamespace(user=SimpleNamespace(user_id=user_id, emails=email_objects))
+
+
+def _verifier(sessions: FakeSessions) -> StytchSdkVerifier:
+    """Build a verifier over a fake client (settings never consulted)."""
+    return StytchSdkVerifier(settings=AuthSettings(), client=_fake_client(sessions))  # type: ignore[arg-type]
+
+
+class TestStytchSdkVerifier(IsolatedAsyncioTestCase):
+    """Token routing, identity mapping, and fail-closed error handling."""
+
+    async def test_opaque_token_verifies_as_session_token(self) -> None:
+        """A dot-less token is authenticated as ``session_token``."""
+        # Arrange
+        sessions = FakeSessions(
+            response=_sdk_response("user-test-1", [("engineer@example.com", True)])
+        )
+
+        # Act
+        verification = await _verifier(sessions).verify("opaque-session-token")
+
+        # Assert
+        assert verification is not None
+        assert verification.user_id == "user-test-1"
+        assert verification.email == "engineer@example.com"
+        assert sessions.calls == [{"session_token": "opaque-session-token", "session_jwt": None}]
+
+    async def test_jwt_shaped_token_verifies_as_session_jwt(self) -> None:
+        """A three-segment token (two dots) is authenticated as ``session_jwt``."""
+        # Arrange
+        sessions = FakeSessions(
+            response=_sdk_response("user-test-2", [("engineer@example.com", True)])
+        )
+        jwt = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.signature"
+
+        # Act
+        verification = await _verifier(sessions).verify(jwt)
+
+        # Assert
+        assert verification is not None
+        assert sessions.calls == [{"session_token": None, "session_jwt": jwt}]
+
+    async def test_verified_email_wins_over_surrounding_unverified_ones(self) -> None:
+        """The verified email is surfaced even when unverified ones precede it."""
+        # Arrange
+        sessions = FakeSessions(
+            response=_sdk_response(
+                "user-test-3",
+                [
+                    ("unverified@example.com", False),
+                    ("verified@example.com", True),
+                    ("another-unverified@example.com", False),
+                ],
+            )
+        )
+
+        # Act
+        verification = await _verifier(sessions).verify("token")
+
+        # Assert
+        assert verification is not None
+        assert verification.email == "verified@example.com"
+
+    async def test_unverified_only_emails_yield_none_email(self) -> None:
+        """With no verified email the identity fails closed to ``email=None``.
+
+        An unverified address must never be surfaced: the callback maps the
+        email onto the users table, so trusting it would allow account
+        takeover by merely entering a victim's email at Stytch.
+        """
+        # Arrange
+        sessions = FakeSessions(
+            response=_sdk_response("user-test-4", [("only@example.com", False)])
+        )
+
+        # Act
+        verification = await _verifier(sessions).verify("token")
+
+        # Assert
+        assert verification is not None
+        assert verification.email is None
+
+    async def test_no_emails_yields_none_email(self) -> None:
+        """An identity without any email verifies with ``email=None``."""
+        # Arrange
+        sessions = FakeSessions(response=_sdk_response("user-test-5", []))
+
+        # Act
+        verification = await _verifier(sessions).verify("token")
+
+        # Assert
+        assert verification is not None
+        assert verification.email is None
+
+    async def test_stytch_error_returns_none(self) -> None:
+        """The SDK's invalid-session error resolves to None, never a raise."""
+        # Arrange
+        sessions = FakeSessions(error=_stytch_error())
+
+        # Act / Assert
+        assert await _verifier(sessions).verify("expired-token") is None
+
+    async def test_unexpected_error_returns_none(self) -> None:
+        """A transport-level failure also fails closed to None."""
+        # Arrange
+        sessions = FakeSessions(error=RuntimeError("connection reset"))
+
+        # Act / Assert
+        assert await _verifier(sessions).verify("any-token") is None
+
+    async def test_missing_configuration_returns_none(self) -> None:
+        """With no client and no project id/secret, verification declines."""
+        # Arrange — settings with explicitly-absent Stytch configuration
+        verifier = StytchSdkVerifier(settings=AuthSettings(stytch_project_id="", stytch_secret=""))
+
+        # Act / Assert
+        assert await verifier.verify("any-token") is None
+
+
+class TestConfigurationResolution:
+    """Configuration is read lazily and only when no client was injected."""
+
+    def test_injected_client_bypasses_settings(self) -> None:
+        """A supplied client is used as-is (no env/settings reads needed)."""
+        # Arrange — settings whose Stytch config is explicitly absent: were the
+        # injected client not used, verification could only fail closed.
+        sessions = FakeSessions(
+            response=_sdk_response("user-test-di", [("engineer@example.com", True)])
+        )
+        verifier = StytchSdkVerifier(
+            settings=AuthSettings(stytch_project_id="", stytch_secret=""),
+            client=_fake_client(sessions),  # type: ignore[arg-type]
+        )
+
+        # Act
+        verification = asyncio.run(verifier.verify("opaque-token"))
+
+        # Assert — the injected client answered despite the empty settings
+        assert verification is not None
+        assert verification.user_id == "user-test-di"
+
+    def test_unconfigured_environment_fails_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without project id and secret in the env, verification declines."""
+        # Arrange
+        monkeypatch.delenv("LAVS_STYTCH_PROJECT_ID", raising=False)
+        monkeypatch.delenv("LAVS_STYTCH_SECRET", raising=False)
+        verifier = StytchSdkVerifier(settings=AuthSettings())
+
+        # Act / Assert
+        assert asyncio.run(verifier.verify("any-token")) is None

--- a/tests/unit/auth/test_auth_settings.py
+++ b/tests/unit/auth/test_auth_settings.py
@@ -9,12 +9,23 @@ _MODES = "LAVS_AUTH_MODES"
 _DOMAINS = "LAVS_ALLOWED_EMAIL_DOMAINS"
 _TTL = "LAVS_SESSION_TTL_SECONDS"
 _EDITION = "LAVS_EDITION"
+_STYTCH_PROJECT_ID = "LAVS_STYTCH_PROJECT_ID"
+_STYTCH_SECRET = "LAVS_STYTCH_SECRET"
+_STYTCH_PUBLIC_TOKEN = "LAVS_STYTCH_PUBLIC_TOKEN"
 
 
 @pytest.fixture(autouse=True)
 def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure a clean environment for every case."""
-    for name in (_MODES, _DOMAINS, _TTL, _EDITION):
+    for name in (
+        _MODES,
+        _DOMAINS,
+        _TTL,
+        _EDITION,
+        _STYTCH_PROJECT_ID,
+        _STYTCH_SECRET,
+        _STYTCH_PUBLIC_TOKEN,
+    ):
         monkeypatch.delenv(name, raising=False)
 
 
@@ -110,3 +121,110 @@ class TestEdition:
 
         # Act / Assert
         assert AuthSettings().edition() == "ee"
+
+
+class TestStytchModeGating:
+    """The ``stytch`` token is honoured on EE only (edition × modes matrix)."""
+
+    @pytest.mark.parametrize(
+        ("edition", "modes_env", "expected"),
+        [
+            (None, "stytch", set()),
+            ("oss", "stytch", set()),
+            ("ee", "stytch", {AuthMode.STYTCH}),
+            (None, "password,stytch", {AuthMode.PASSWORD}),
+            ("oss", "password,stytch", {AuthMode.PASSWORD}),
+            ("ee", "password,stytch", {AuthMode.PASSWORD, AuthMode.STYTCH}),
+            ("ee", "stytch,apikey", {AuthMode.STYTCH, AuthMode.APIKEY}),
+            ("ee", "password,apikey", {AuthMode.PASSWORD, AuthMode.APIKEY}),
+        ],
+    )
+    def test_edition_gates_the_stytch_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        edition: str | None,
+        modes_env: str,
+        expected: set[AuthMode],
+    ) -> None:
+        """``stytch`` in ``LAVS_AUTH_MODES`` only takes effect when edition is ``ee``."""
+        # Arrange
+        monkeypatch.setenv(_MODES, modes_env)
+        if edition is not None:
+            monkeypatch.setenv(_EDITION, edition)
+
+        # Act / Assert
+        assert AuthSettings().modes() == expected
+
+    def test_stytch_enabled_true_on_ee(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``stytch_enabled`` reflects an EE deployment with the mode configured."""
+        # Arrange
+        monkeypatch.setenv(_MODES, "stytch")
+        monkeypatch.setenv(_EDITION, "ee")
+
+        # Act / Assert
+        assert AuthSettings().stytch_enabled() is True
+
+    def test_stytch_enabled_false_on_oss(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On OSS the configured ``stytch`` token stays ignored, exactly as before EE."""
+        # Arrange
+        monkeypatch.setenv(_MODES, "stytch")
+
+        # Act / Assert
+        assert AuthSettings().stytch_enabled() is False
+
+    def test_case_and_space_tolerant_on_ee(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The stytch token parses with the same tolerance as the other modes."""
+        # Arrange
+        monkeypatch.setenv(_MODES, " Stytch ")
+        monkeypatch.setenv(_EDITION, "ee")
+
+        # Act / Assert
+        assert AuthSettings().modes() == {AuthMode.STYTCH}
+
+
+class TestStytchConfig:
+    """``LAVS_STYTCH_*`` accessors (project id, secret, public token)."""
+
+    def test_unset_values_are_none(self) -> None:
+        """With nothing configured every Stytch accessor returns None."""
+        # Arrange
+        settings = AuthSettings()
+
+        # Act / Assert
+        assert settings.stytch_project_id() is None
+        assert settings.stytch_secret() is None
+        assert settings.stytch_public_token() is None
+
+    def test_reads_env_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Each accessor reads (and trims) its environment variable on demand."""
+        # Arrange
+        monkeypatch.setenv(_STYTCH_PROJECT_ID, " project-test-123 ")
+        monkeypatch.setenv(_STYTCH_SECRET, "secret-test-456")
+        monkeypatch.setenv(_STYTCH_PUBLIC_TOKEN, "public-token-789")
+
+        # Act
+        settings = AuthSettings()
+
+        # Assert
+        assert settings.stytch_project_id() == "project-test-123"
+        assert settings.stytch_secret() == "secret-test-456"
+        assert settings.stytch_public_token() == "public-token-789"
+
+    def test_blank_env_values_are_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A whitespace-only env value counts as unconfigured."""
+        # Arrange
+        monkeypatch.setenv(_STYTCH_PROJECT_ID, "   ")
+        monkeypatch.setenv(_STYTCH_SECRET, "")
+
+        # Act / Assert
+        assert AuthSettings().stytch_project_id() is None
+        assert AuthSettings().stytch_secret() is None
+
+    def test_injected_values_override_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Constructor-injected values win over the environment entirely."""
+        # Arrange
+        monkeypatch.setenv(_STYTCH_PROJECT_ID, "env-project")
+        settings = AuthSettings(stytch_project_id="injected-project")
+
+        # Act / Assert
+        assert settings.stytch_project_id() == "injected-project"

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,85 @@ constraints = [
 ]
 
 [[package]]
+name = "aiohappyeyeballs"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f4/eec0465c2f67b2664688d0240b3212d5196fd89e741df67ddb81f8d35658/aiohappyeyeballs-2.7.1.tar.gz", hash = "sha256:065665c041c42a5938ed220bdcd7230f22527fbec085e1853d2402c8a3615d9d", size = 24757, upload-time = "2026-07-01T17:11:55.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl", hash = "sha256:9243213661e29250eb41368e5daa826fc017156c3b8a11440826b2e3ed376472", size = 15038, upload-time = "2026-07-01T17:11:54.055Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/d9/22ce5786ac0c1653ae8b6c23bded02c1686d11f0dbb45b31ce128e0df985/aiohttp-3.14.3.tar.gz", hash = "sha256:9491196535a88924a60afd5b5f434b5b203b6cc616250878dbdb223a8f7844bc", size = 7971213, upload-time = "2026-07-23T01:57:27.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/20/887fdcf832326571b370ffc347b3e70abe101096f3720126aac161b1d872/aiohttp-3.14.3-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:49f7325beb0f85ef4aef5f48f490269575f83e6e2acad00a1d80b807eb027062", size = 509067, upload-time = "2026-07-23T01:55:42.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a3/92cec936f78cc4bf0fa5554ebe593b73459d94e3c62303e1902a4cccb6f7/aiohttp-3.14.3-cp314-cp314-android_24_x86_64.whl", hash = "sha256:e3be98a7c30b8c25d573dafba7171d66dfb05ee6a9070fc46535464ff97700a6", size = 514774, upload-time = "2026-07-23T01:55:44.937Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ba/2a0c38df3fc557620b6a5acd98364af050053b6285b4dc7ee74100c63c18/aiohttp-3.14.3-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:614c61d478b83953e261d02bb2df750f17227cd33ef8002945bf5aebbde21919", size = 488134, upload-time = "2026-07-23T01:55:47.135Z" },
+    { url = "https://files.pythonhosted.org/packages/48/d6/d51b7d4bf309af3693940d8ffd2b9ed0b682434ef85959b7c9c137f60cf8/aiohttp-3.14.3-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:1caa7b0d05f3e3a36f87788c59e970a7ee1cefcfcbb924a9f138c4a6551c9cb7", size = 494201, upload-time = "2026-07-23T01:55:49.451Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5a/8f624384e5f1efabb5229b94157eb966b021e97bdb188c62860c2ae243c2/aiohttp-3.14.3-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:dfa68deb2a443bdaa3ea5297b0699c1464f08aef3812b486d1348eee61b07dc0", size = 502766, upload-time = "2026-07-23T01:55:51.656Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/26/4ff0164370deec18fb19254ee4ab10b7a73304ac0c860b13f5f84663759b/aiohttp-3.14.3-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e72ee89e28d907a18f46959b4eb0bb06701cc7f8cf4366e00029e2ccfaaf5924", size = 756557, upload-time = "2026-07-23T01:55:53.964Z" },
+    { url = "https://files.pythonhosted.org/packages/97/a3/7056b86dc0d9ec709ea9777eae3b0161428f943372f8b98c01c11593b682/aiohttp-3.14.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ad4c8b7488d745d2ca4838ebd8ae5ba9b56341d30b1da43640e4ce87f9f49646", size = 510168, upload-time = "2026-07-23T01:55:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/0357a015892fd68058bf2d39d3fd1958e459b997a7db30aaa6aaa434ae96/aiohttp-3.14.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:db332af25642007330fca8be5c4d194caf2bea7a7fc84415aff3497af5dfee6b", size = 512957, upload-time = "2026-07-23T01:55:58.437Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d1/8aba53f15ccb2238405f5e9d30e2a8ca44f93878c26e7165ade00d374b1c/aiohttp-3.14.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25bd2708db6bdf6a6630dd37bdcdfcb47c4434d22ac69c64665b802910140b30", size = 1750149, upload-time = "2026-07-23T01:56:00.856Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/40c3fee327529284375c6701cbb0fa4600cc2e8432af1378f897e2ef7d3a/aiohttp-3.14.3-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:cef89a58e628c4efcac3275c2d68083f82426dcdc89c1492a6f654f9f7ea6ab9", size = 1707685, upload-time = "2026-07-23T01:56:03.371Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a3/ca0cc6724cca8114b05694abd916060758c79894c3aa5b012cdadc1bc28e/aiohttp-3.14.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c23ec8ee9d5ab2f5421f9c7fffce208435607af27fd46d4a44e031954352838f", size = 1803911, upload-time = "2026-07-23T01:56:05.817Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b5/85b099c299c3ffd38ad9b3e43694c8a346934e4a30c88c4fd5a841234f77/aiohttp-3.14.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e2667f0bbe7eb6c74eae5e9691441ad186e5845ca3cff63230fc09c4e7514f5d", size = 1876929, upload-time = "2026-07-23T01:56:08.413Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/b7/1da684a04175473fa4cddbf9a2f572e79514c3fd27a74597f43057d4f3da/aiohttp-3.14.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18cb43369747b2ae007bd2655fb8e63a099c2ff1d207962943636dac989b3147", size = 1761112, upload-time = "2026-07-23T01:56:10.918Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/16/bc4b55e3e5cb175fd69c53c90d60d2f47797cb343da5106e23863dc4dba4/aiohttp-3.14.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d77640cc618c1d99fc4f8589c0f24a730adfa54eb1e57ef7bf0c8dfb78da898c", size = 1583500, upload-time = "2026-07-23T01:56:13.613Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/e8/13a9d957a1ee40837f46aa30f0f4c657e673ad86a2e6362a9f9be20d26d9/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:53e5179d8abb5710f8e83ba207c41c8d1261fcffd4616500e15ca2b7a33be10a", size = 1713940, upload-time = "2026-07-23T01:56:15.969Z" },
+    { url = "https://files.pythonhosted.org/packages/38/05/d33c680c1bcf1c7e130f9cbfc1fc02fe8bb0c4af2a94a53dd5fb56131e5c/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:cd817772b2fcf2b8c0905795318485f9ec16eae60b29feb7f4c77085311637f0", size = 1724413, upload-time = "2026-07-23T01:56:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/85/1d/af798d306f7a74b6a632dbcabcf62a4c91391b7582d2a8c6d7712e2cc54e/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:4e3ac92d90e92773b2362d506068e9a948192bd553e743c5b2429e28527c8661", size = 1770748, upload-time = "2026-07-23T01:56:21.074Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/92/ad720d472556a995049206867765e9410969684f86ee09423ff9969044c1/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3f42e9b78301f11c8f861746175d8b9c1ccef713fcad9eab396e2f6db8ed4a22", size = 1577564, upload-time = "2026-07-23T01:56:23.475Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ad/0ed7586cbef7a884e23a752fa2bb987a122e6a5dd50dab109258d0a95193/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9d9edccfe496b476db5f398d97b865e9a6752bcf8aec4eef8390ce20fb64bb41", size = 1782080, upload-time = "2026-07-23T01:56:25.994Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ea/dbaed0d73e8a69aad653b045dab451c67c2454bb731a37b45a86593e9422/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1c5ec8fb1bcc31a8466f74aaf26c345d5c386fa4bd08a3f0eb9c7a4a3fe8b5bf", size = 1745813, upload-time = "2026-07-23T01:56:28.604Z" },
+    { url = "https://files.pythonhosted.org/packages/81/1b/6893d4bc57e434fc93a6c9217c637d967a0b651d989f6e3265179375754a/aiohttp-3.14.3-cp314-cp314-win32.whl", hash = "sha256:38901a84da3ce22249f6e860bf8f90d141bcab7da090cc398f8bb58c0e44b7da", size = 455872, upload-time = "2026-07-23T01:56:31.031Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/8b/c7baa1ba1eda4db6989baefe5de6d99834921b84ebd7918624febcb9f290/aiohttp-3.14.3-cp314-cp314-win_amd64.whl", hash = "sha256:8b3b60de05f3dcb6f6a00f818bb2ec781cee4de0645f59ccaf99b1d1823b6100", size = 481030, upload-time = "2026-07-23T01:56:33.365Z" },
+    { url = "https://files.pythonhosted.org/packages/22/8c/c29d067df825a2df88ca432db848aa2fe8199598359cc06c12b09320cac9/aiohttp-3.14.3-cp314-cp314-win_arm64.whl", hash = "sha256:1576145bdceeb92382d899751e12743a3a5b8e460a841e3e50543859e54864dc", size = 453669, upload-time = "2026-07-23T01:56:35.731Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a4/9c033beb355d39b6147980597ec9645e4729243f686ee4dc73945de72030/aiohttp-3.14.3-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8800c996b01c2772a783e3e46f3e1abd5823029adca0df54231960de9bfefa5b", size = 791403, upload-time = "2026-07-23T01:56:37.972Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ca/87c32a0a7704583cfc49660bd817889bae5b830bf53b5dcb4e92145ac2da/aiohttp-3.14.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ebe8e504f058fe91223351cecd2d9d6946c9d241bb0250d898ffbdf584cc72b0", size = 526413, upload-time = "2026-07-23T01:56:40.523Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d8/8ec0e471248c500acdce2be3f46db8fb62b5eb60efef072529cc85ee1d26/aiohttp-3.14.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30402d03a7c0ff52bce290b57e564e9079fd9d0cb545c8aba73f86a103162d2e", size = 532135, upload-time = "2026-07-23T01:56:42.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/45/f8919fd936e8b79fcd9bda7b6d8e62613462a713f4f17987fd7c34399142/aiohttp-3.14.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9fc7b5bfec6573f3ae844f457fdde5adeb713f8b8e4a81ad64fc207b49383716", size = 1922742, upload-time = "2026-07-23T01:56:45.528Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ec/9ca76b28a27525b0cc53e20842e0228b022f301ce1f436b7d814b4aaf2df/aiohttp-3.14.3-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8a5fd34f7f7410d1730d5c2ba873cacb2eed3fede366feb268a70ba22581ed8f", size = 1787371, upload-time = "2026-07-23T01:56:48.045Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/04/6acdbf17315f7b55f1937e3387acb89a3cddeb4995689553d064af8e92ab/aiohttp-3.14.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:270d3dace9ca2f10f0da5d8ebe519b7a310fc6112ed916e32df5866df0888553", size = 1912623, upload-time = "2026-07-23T01:56:50.605Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e6/438b0c79ca6f45eb9fd9817dd4c01a91919a38c0de5ee9e05e2b4dc0ece7/aiohttp-3.14.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3ae5b3a59436d089b5395d910121a390feed4d00578eb95a0fd1a329fe963100", size = 2005515, upload-time = "2026-07-23T01:56:53.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/6b/62cbd6577758699525f5c712d1ddef57d9875fbab0ae8d5f5a202fd598f8/aiohttp-3.14.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2498f0fe69ead802f9675beca44a7c21c62fdaa4ec5145ea1c3ad6edbee29f85", size = 1879906, upload-time = "2026-07-23T01:56:55.818Z" },
+    { url = "https://files.pythonhosted.org/packages/00/95/18bcbf830a21dc3aae24d8f6b6feaf3db1d2090242d00a7868db2ffb0b67/aiohttp-3.14.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a0dc483c00da8b673abbb367eb6f8d8f4bcec30eb58529ea13cb42e7fd2dfa33", size = 1675849, upload-time = "2026-07-23T01:56:58.861Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/19/47f4968659c5e23606c3790c80fc624e691c153d036148449ee84d31b287/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c7d3a97c678d34fc5b59da671ee9cd630096ddc643e7b5a30d54a2a6f3574d3f", size = 1843496, upload-time = "2026-07-23T01:57:01.591Z" },
+    { url = "https://files.pythonhosted.org/packages/64/af/38c33c4dd82fddcb4e56c4653b6f1072a8edbc6b7fa15809f14932c41e2d/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f8fb78a83c9e5f741ca3a68cfb455c1f5bb83b4e7249a3848b3cd78d0a8563b0", size = 1827746, upload-time = "2026-07-23T01:57:05.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9d/0537cda4885ac8f5b7053d164dd06312f4c483a4edcb8ee5b8aaf2a989bf/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:74ab5b6a9fb13e873e5a90946588baecaf488745e1db1a4a5c433f971f035098", size = 1853810, upload-time = "2026-07-23T01:57:08.043Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fe/26f9c5e6458385aa86497836b0dea6fb2f027827d63f37c7856cce9286ee/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:bd52f811e65f6fb634b1047159657c98f52b407f8efec907bcfc09da9a4c0a25", size = 1668895, upload-time = "2026-07-23T01:57:10.837Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/4c/618b1db9b9ba079b8875d2cdf78e7c4a3bf72903bd5850fee7dd9544600a/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:f0f177d1b195b9e06376cfd7d308d8a1b920909a609d03ac82a8c73bbb16d3b9", size = 1883833, upload-time = "2026-07-23T01:57:13.672Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c6/bd959bd1e4771f9fd944e9e436224c48c77b018b73b519b5aad346335bcc/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:498c6c623134f8e09a3c4e60bcd607a0b4590dd7dbf08dd40851b27cbb520ccb", size = 1844251, upload-time = "2026-07-23T01:57:16.593Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/19/08d41839658bdd44a0ed2480f3891705ecb487ce28c0dde62c9040c997e0/aiohttp-3.14.3-cp314-cp314t-win32.whl", hash = "sha256:b304db572b4368edd8dda8a2274f73156fe15558fca4a917cb8a09fc47af5963", size = 474180, upload-time = "2026-07-23T01:57:19.306Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/3cd6ef0a2b2851f7ab913b5b079334781bd50ff56a323e4454063377a080/aiohttp-3.14.3-cp314-cp314t-win_amd64.whl", hash = "sha256:b20032766aedf6261c7a566585a40867d092ac03a0d81592d5370ef9b054f99b", size = 500528, upload-time = "2026-07-23T01:57:21.762Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/37/cfd1ed540a4d318da025590d96b728e63713c09e9377950fc655dadeb856/aiohttp-3.14.3-cp314-cp314t-win_arm64.whl", hash = "sha256:2e1161602f45a54de2ce0905243a95f58cb42dcd378402f3697f5e0b21e9d2e7", size = 469280, upload-time = "2026-07-23T01:57:24.241Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -80,6 +159,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
     { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
     { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -269,6 +357,56 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -329,6 +467,47 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8b/4c32ecde6bea6486a2a5d05340e695174351ff6b06cf651a74c005f9df00/filelock-3.25.1.tar.gz", hash = "sha256:b9a2e977f794ef94d77cdf7d27129ac648a61f585bff3ca24630c1629f701aa9", size = 40319, upload-time = "2026-03-09T19:38:47.309Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/b8/2f664b56a3b4b32d28d3d106c71783073f712ba43ff6d34b9ea0ce36dc7b/filelock-3.25.1-py3-none-any.whl", hash = "sha256:18972df45473c4aa2c7921b609ee9ca4925910cc3a0fb226c96b92fc224ef7bf", size = 26720, upload-time = "2026-03-09T19:38:45.718Z" },
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/c8/85da824b7e7b9b6e7f7705b2ecaf9591ba6f79c1177f324c2735e41d36a2/frozenlist-1.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cee686f1f4cadeb2136007ddedd0aaf928ab95216e7691c63e50a8ec066336d0", size = 86127, upload-time = "2025-10-06T05:37:08.438Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:119fb2a1bd47307e899c2fac7f28e85b9a543864df47aa7ec9d3c1b4545f096f", size = 49698, upload-time = "2025-10-06T05:37:09.48Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4970ece02dbc8c3a92fcc5228e36a3e933a01a999f7094ff7c23fbd2beeaa67c", size = 49749, upload-time = "2025-10-06T05:37:10.569Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cba69cb73723c3f329622e34bdbf5ce1f80c21c290ff04256cff1cd3c2036ed2", size = 231298, upload-time = "2025-10-06T05:37:11.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:778a11b15673f6f1df23d9586f83c4846c471a8af693a22e066508b77d201ec8", size = 232015, upload-time = "2025-10-06T05:37:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/be719d2766c1138148564a3960fc2c06eb688da592bdc25adcf856101be7/frozenlist-1.8.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686", size = 225038, upload-time = "2025-10-06T05:37:14.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/09/6712b6c5465f083f52f50cf74167b92d4ea2f50e46a9eea0523d658454ae/frozenlist-1.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:97260ff46b207a82a7567b581ab4190bd4dfa09f4db8a8b49d1a958f6aa4940e", size = 240130, upload-time = "2025-10-06T05:37:15.781Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d4/cd065cdcf21550b54f3ce6a22e143ac9e4836ca42a0de1022da8498eac89/frozenlist-1.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54b2077180eb7f83dd52c40b2750d0a9f175e06a42e3213ce047219de902717a", size = 242845, upload-time = "2025-10-06T05:37:17.037Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c3/f57a5c8c70cd1ead3d5d5f776f89d33110b1addae0ab010ad774d9a44fb9/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2f05983daecab868a31e1da44462873306d3cbfd76d1f0b5b69c473d21dbb128", size = 229131, upload-time = "2025-10-06T05:37:18.221Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/52/232476fe9cb64f0742f3fde2b7d26c1dac18b6d62071c74d4ded55e0ef94/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:33f48f51a446114bc5d251fb2954ab0164d5be02ad3382abcbfe07e2531d650f", size = 240542, upload-time = "2025-10-06T05:37:19.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/07bf3f5d0fb5414aee5f47d33c6f5c77bfe49aac680bfece33d4fdf6a246/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:154e55ec0655291b5dd1b8731c637ecdb50975a2ae70c606d100750a540082f7", size = 237308, upload-time = "2025-10-06T05:37:20.969Z" },
+    { url = "https://files.pythonhosted.org/packages/11/99/ae3a33d5befd41ac0ca2cc7fd3aa707c9c324de2e89db0e0f45db9a64c26/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:4314debad13beb564b708b4a496020e5306c7333fa9a3ab90374169a20ffab30", size = 238210, upload-time = "2025-10-06T05:37:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/60/b1d2da22f4970e7a155f0adde9b1435712ece01b3cd45ba63702aea33938/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:073f8bf8becba60aa931eb3bc420b217bb7d5b8f4750e6f8b3be7f3da85d38b7", size = 231972, upload-time = "2025-10-06T05:37:23.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ab/945b2f32de889993b9c9133216c068b7fcf257d8595a0ac420ac8677cab0/frozenlist-1.8.0-cp314-cp314-win32.whl", hash = "sha256:bac9c42ba2ac65ddc115d930c78d24ab8d4f465fd3fc473cdedfccadb9429806", size = 40536, upload-time = "2025-10-06T05:37:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:3e0761f4d1a44f1d1a47996511752cf3dcec5bbdd9cc2b4fe595caf97754b7a0", size = 44330, upload-time = "2025-10-06T05:37:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/82/13/e6950121764f2676f43534c555249f57030150260aee9dcf7d64efda11dd/frozenlist-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:d1eaff1d00c7751b7c6662e9c5ba6eb2c17a2306ba5e2a37f24ddf3cc953402b", size = 40627, upload-time = "2025-10-06T05:37:28.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c7/43200656ecc4e02d3f8bc248df68256cd9572b3f0017f0a0c4e93440ae23/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:d3bb933317c52d7ea5004a1c442eef86f426886fba134ef8cf4226ea6ee1821d", size = 89238, upload-time = "2025-10-06T05:37:29.373Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/29/55c5f0689b9c0fb765055629f472c0de484dcaf0acee2f7707266ae3583c/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8009897cdef112072f93a0efdce29cd819e717fd2f649ee3016efd3cd885a7ed", size = 50738, upload-time = "2025-10-06T05:37:30.792Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7d/b7282a445956506fa11da8c2db7d276adcbf2b17d8bb8407a47685263f90/frozenlist-1.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c5dcbbc55383e5883246d11fd179782a9d07a986c40f49abe89ddf865913930", size = 51739, upload-time = "2025-10-06T05:37:32.127Z" },
+    { url = "https://files.pythonhosted.org/packages/62/1c/3d8622e60d0b767a5510d1d3cf21065b9db874696a51ea6d7a43180a259c/frozenlist-1.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:39ecbc32f1390387d2aa4f5a995e465e9e2f79ba3adcac92d68e3e0afae6657c", size = 284186, upload-time = "2025-10-06T05:37:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/14/aa36d5f85a89679a85a1d44cd7a6657e0b1c75f61e7cad987b203d2daca8/frozenlist-1.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92db2bf818d5cc8d9c1f1fc56b897662e24ea5adb36ad1f1d82875bd64e03c24", size = 292196, upload-time = "2025-10-06T05:37:36.107Z" },
+    { url = "https://files.pythonhosted.org/packages/05/23/6bde59eb55abd407d34f77d39a5126fb7b4f109a3f611d3929f14b700c66/frozenlist-1.8.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dc43a022e555de94c3b68a4ef0b11c4f747d12c024a520c7101709a2144fb37", size = 273830, upload-time = "2025-10-06T05:37:37.663Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3f/22cff331bfad7a8afa616289000ba793347fcd7bc275f3b28ecea2a27909/frozenlist-1.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb89a7f2de3602cfed448095bab3f178399646ab7c61454315089787df07733a", size = 294289, upload-time = "2025-10-06T05:37:39.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/89/5b057c799de4838b6c69aa82b79705f2027615e01be996d2486a69ca99c4/frozenlist-1.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:33139dc858c580ea50e7e60a1b0ea003efa1fd42e6ec7fdbad78fff65fad2fd2", size = 300318, upload-time = "2025-10-06T05:37:43.213Z" },
+    { url = "https://files.pythonhosted.org/packages/30/de/2c22ab3eb2a8af6d69dc799e48455813bab3690c760de58e1bf43b36da3e/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:168c0969a329b416119507ba30b9ea13688fafffac1b7822802537569a1cb0ef", size = 282814, upload-time = "2025-10-06T05:37:45.337Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f7/970141a6a8dbd7f556d94977858cfb36fa9b66e0892c6dd780d2219d8cd8/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:28bd570e8e189d7f7b001966435f9dac6718324b5be2990ac496cf1ea9ddb7fe", size = 291762, upload-time = "2025-10-06T05:37:46.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/15/ca1adae83a719f82df9116d66f5bb28bb95557b3951903d39135620ef157/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b2a095d45c5d46e5e79ba1e5b9cb787f541a8dee0433836cea4b96a2c439dcd8", size = 289470, upload-time = "2025-10-06T05:37:47.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/83/dca6dc53bf657d371fbc88ddeb21b79891e747189c5de990b9dfff2ccba1/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:eab8145831a0d56ec9c4139b6c3e594c7a83c2c8be25d5bcf2d86136a532287a", size = 289042, upload-time = "2025-10-06T05:37:49.499Z" },
+    { url = "https://files.pythonhosted.org/packages/96/52/abddd34ca99be142f354398700536c5bd315880ed0a213812bc491cff5e4/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:974b28cf63cc99dfb2188d8d222bc6843656188164848c4f679e63dae4b0708e", size = 283148, upload-time = "2025-10-06T05:37:50.745Z" },
+    { url = "https://files.pythonhosted.org/packages/af/d3/76bd4ed4317e7119c2b7f57c3f6934aba26d277acc6309f873341640e21f/frozenlist-1.8.0-cp314-cp314t-win32.whl", hash = "sha256:342c97bf697ac5480c0a7ec73cd700ecfa5a8a40ac923bd035484616efecc2df", size = 44676, upload-time = "2025-10-06T05:37:52.222Z" },
+    { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
 ]
 
 [[package]]
@@ -407,6 +586,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-ulid" },
     { name = "pyyaml" },
+    { name = "stytch" },
     { name = "uvicorn" },
 ]
 
@@ -431,6 +611,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "python-ulid", specifier = ">=3.1.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "stytch", specifier = ">=15.3.0" },
     { name = "uvicorn", specifier = ">=0.40.0" },
 ]
 
@@ -444,6 +625,51 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.8.0" },
     { name = "testcontainers", extras = ["postgres"], specifier = ">=4.14.2" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/cc/db74228a8be41884a567e88a62fd589a913708fcf180d029898c17a9a371/multidict-6.7.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8f333ec9c5eb1b7105e3b84b53141e66ca05a19a605368c55450b6ba208cb9ee", size = 75190, upload-time = "2026-01-26T02:45:10.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a407f13c188f804c759fc6a9f88286a565c242a76b27626594c133b82883b5c2", size = 44486, upload-time = "2026-01-26T02:45:11.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0e161ddf326db5577c3a4cc2d8648f81456e8a20d40415541587a71620d7a7d1", size = 43219, upload-time = "2026-01-26T02:45:14.346Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bb/2c0c2287963f4259c85e8bcbba9182ced8d7fca65c780c38e99e61629d11/multidict-6.7.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1e3a8bb24342a8201d178c3b4984c26ba81a577c80d4d525727427460a50c22d", size = 245132, upload-time = "2026-01-26T02:45:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97231140a50f5d447d3164f994b86a0bed7cd016e2682f8650d6a9158e14fd31", size = 252420, upload-time = "2026-01-26T02:45:17.293Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/78f7275e73fa17b24c9a51b0bd9d73ba64bb32d0ed51b02a746eb876abe7/multidict-6.7.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b10359683bd8806a200fd2909e7c8ca3a7b24ec1d8132e483d58e791d881048", size = 233510, upload-time = "2026-01-26T02:45:19.356Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/8167187f62ae3cbd52da7893f58cb036b47ea3fb67138787c76800158982/multidict-6.7.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:283ddac99f7ac25a4acadbf004cb5ae34480bbeb063520f70ce397b281859362", size = 264094, upload-time = "2026-01-26T02:45:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e7/69a3a83b7b030cf283fb06ce074a05a02322359783424d7edf0f15fe5022/multidict-6.7.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:538cec1e18c067d0e6103aa9a74f9e832904c957adc260e61cd9d8cf0c3b3d37", size = 260786, upload-time = "2026-01-26T02:45:22.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7eee46ccb30ff48a1e35bb818cc90846c6be2b68240e42a78599166722cea709", size = 248483, upload-time = "2026-01-26T02:45:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/d5a99e3acbca0e29c5d9cba8f92ceb15dce78bab963b308ae692981e3a5d/multidict-6.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa263a02f4f2dd2d11a7b1bb4362aa7cb1049f84a9235d31adf63f30143469a0", size = 248403, upload-time = "2026-01-26T02:45:25.982Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/e58cd31f6c7d5102f2a4bf89f96b9cf7e00b6c6f3d04ecc44417c00a5a3c/multidict-6.7.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:2e1425e2f99ec5bd36c15a01b690a1a2456209c5deed58f95469ffb46039ccbb", size = 240315, upload-time = "2026-01-26T02:45:27.487Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/1cd210229559cb90b6786c30676bb0c58249ff42f942765f88793b41fdce/multidict-6.7.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:497394b3239fc6f0e13a78a3e1b61296e72bf1c5f94b4c4eb80b265c37a131cd", size = 245528, upload-time = "2026-01-26T02:45:28.991Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f2/6e1107d226278c876c783056b7db43d800bb64c6131cec9c8dfb6903698e/multidict-6.7.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:233b398c29d3f1b9676b4b6f75c518a06fcb2ea0b925119fb2c1bc35c05e1601", size = 258784, upload-time = "2026-01-26T02:45:30.503Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c1/11f664f14d525e4a1b5327a82d4de61a1db604ab34c6603bb3c2cc63ad34/multidict-6.7.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:93b1818e4a6e0930454f0f2af7dfce69307ca03cdcfb3739bf4d91241967b6c1", size = 251980, upload-time = "2026-01-26T02:45:32.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9f/75a9ac888121d0c5bbd4ecf4eead45668b1766f6baabfb3b7f66a410e231/multidict-6.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f33dc2a3abe9249ea5d8360f969ec7f4142e7ac45ee7014d8f8d5acddf178b7b", size = 243602, upload-time = "2026-01-26T02:45:34.043Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e7/50bf7b004cc8525d80dbbbedfdc7aed3e4c323810890be4413e589074032/multidict-6.7.1-cp314-cp314-win32.whl", hash = "sha256:3ab8b9d8b75aef9df299595d5388b14530839f6422333357af1339443cff777d", size = 40930, upload-time = "2026-01-26T02:45:36.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/bf/52f25716bbe93745595800f36fb17b73711f14da59ed0bb2eba141bc9f0f/multidict-6.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:5e01429a929600e7dab7b166062d9bb54a5eed752384c7384c968c2afab8f50f", size = 45074, upload-time = "2026-01-26T02:45:37.546Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ab/22803b03285fa3a525f48217963da3a65ae40f6a1b6f6cf2768879e208f9/multidict-6.7.1-cp314-cp314-win_arm64.whl", hash = "sha256:4885cb0e817aef5d00a2e8451d4665c1808378dc27c2705f1bf4ef8505c0d2e5", size = 42471, upload-time = "2026-01-26T02:45:38.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/6d/f9293baa6146ba9507e360ea0292b6422b016907c393e2f63fc40ab7b7b5/multidict-6.7.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0458c978acd8e6ea53c81eefaddbbee9c6c5e591f41b3f5e8e194780fe026581", size = 82401, upload-time = "2026-01-26T02:45:40.254Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/53b5494738d83558d87c3c71a486504d8373421c3e0dbb6d0db48ad42ee0/multidict-6.7.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c0abd12629b0af3cf590982c0b413b1e7395cd4ec026f30986818ab95bfaa94a", size = 48143, upload-time = "2026-01-26T02:45:41.635Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e8/5284c53310dcdc99ce5d66563f6e5773531a9b9fe9ec7a615e9bc306b05f/multidict-6.7.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:14525a5f61d7d0c94b368a42cff4c9a4e7ba2d52e2672a7b23d84dc86fb02b0c", size = 46507, upload-time = "2026-01-26T02:45:42.99Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/fc/6800d0e5b3875568b4083ecf5f310dcf91d86d52573160834fb4bfcf5e4f/multidict-6.7.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17307b22c217b4cf05033dabefe68255a534d637c6c9b0cc8382718f87be4262", size = 239358, upload-time = "2026-01-26T02:45:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/41/75/4ad0973179361cdf3a113905e6e088173198349131be2b390f9fa4da5fc6/multidict-6.7.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a7e590ff876a3eaf1c02a4dfe0724b6e69a9e9de6d8f556816f29c496046e59", size = 246884, upload-time = "2026-01-26T02:45:47.167Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9c/095bb28b5da139bd41fb9a5d5caff412584f377914bd8787c2aa98717130/multidict-6.7.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5fa6a95dfee63893d80a34758cd0e0c118a30b8dcb46372bf75106c591b77889", size = 225878, upload-time = "2026-01-26T02:45:48.698Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d0/c0a72000243756e8f5a277b6b514fa005f2c73d481b7d9e47cd4568aa2e4/multidict-6.7.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a0543217a6a017692aa6ae5cc39adb75e587af0f3a82288b1492eb73dd6cc2a4", size = 253542, upload-time = "2026-01-26T02:45:50.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/6b/f69da15289e384ecf2a68837ec8b5ad8c33e973aa18b266f50fe55f24b8c/multidict-6.7.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f99fe611c312b3c1c0ace793f92464d8cd263cc3b26b5721950d977b006b6c4d", size = 252403, upload-time = "2026-01-26T02:45:51.779Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/76/b9669547afa5a1a25cd93eaca91c0da1c095b06b6d2d8ec25b713588d3a1/multidict-6.7.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9004d8386d133b7e6135679424c91b0b854d2d164af6ea3f289f8f2761064609", size = 244889, upload-time = "2026-01-26T02:45:53.27Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a9/a50d2669e506dad33cfc45b5d574a205587b7b8a5f426f2fbb2e90882588/multidict-6.7.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e628ef0e6859ffd8273c69412a2465c4be4a9517d07261b33334b5ec6f3c7489", size = 241982, upload-time = "2026-01-26T02:45:54.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/bb/1609558ad8b456b4827d3c5a5b775c93b87878fd3117ed3db3423dfbce1b/multidict-6.7.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:841189848ba629c3552035a6a7f5bf3b02eb304e9fea7492ca220a8eda6b0e5c", size = 232415, upload-time = "2026-01-26T02:45:56.981Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/59/6f61039d2aa9261871e03ab9dc058a550d240f25859b05b67fd70f80d4b3/multidict-6.7.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ce1bbd7d780bb5a0da032e095c951f7014d6b0a205f8318308140f1a6aba159e", size = 240337, upload-time = "2026-01-26T02:45:58.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/29/fdc6a43c203890dc2ae9249971ecd0c41deaedfe00d25cb6564b2edd99eb/multidict-6.7.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b26684587228afed0d50cf804cc71062cc9c1cdf55051c4c6345d372947b268c", size = 248788, upload-time = "2026-01-26T02:46:00.862Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/14/a153a06101323e4cf086ecee3faadba52ff71633d471f9685c42e3736163/multidict-6.7.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9f9af11306994335398293f9958071019e3ab95e9a707dc1383a35613f6abcb9", size = 242842, upload-time = "2026-01-26T02:46:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/604ae839e64a4a6efc80db94465348d3b328ee955e37acb24badbcd24d83/multidict-6.7.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b4938326284c4f1224178a560987b6cf8b4d38458b113d9b8c1db1a836e640a2", size = 240237, upload-time = "2026-01-26T02:46:05.898Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/c3a5187bf66f6fb546ff4ab8fb5a077cbdd832d7b1908d4365c7f74a1917/multidict-6.7.1-cp314-cp314t-win32.whl", hash = "sha256:98655c737850c064a65e006a3df7c997cd3b220be4ec8fe26215760b9697d4d7", size = 48008, upload-time = "2026-01-26T02:46:07.468Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
 ]
 
 [[package]]
@@ -496,6 +722,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/ea/23ee535d90ce8bcc465a3028eb3cc0ce3bd1005f4bb27710b30587de798d/propcache-0.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:46088abff4cba581dea21ae0467a480526cb25aa5f3c269e909f800328bc3999", size = 94662, upload-time = "2026-05-08T21:01:22.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/06/c5a52f419b5d8972f8d46a7577476090d8e3263ff589ce40b5ca4968d5be/propcache-0.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fc88b26f08d634f7bc819a7852e5214f5802641ab8d9fd5326892292eee1993e", size = 53928, upload-time = "2026-05-08T21:01:23.986Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b1/4260d67d6bd85e58a66b72d54ce15d5de789b6f3870cc6bedf8ff9667401/propcache-0.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:97797ebb098e670a2f92dd66f32897e30d7615b14e7f59711de23e30a9072539", size = 54650, upload-time = "2026-05-08T21:01:25.305Z" },
+    { url = "https://files.pythonhosted.org/packages/70/06/2f46c318e3307cd7a6a7481def374ce838c0fe20084b39dd54b0879d0e99/propcache-0.5.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba57fffe4ac99c5d30076161b5866336d97600769bad35cc68f7774b15298a4e", size = 59912, upload-time = "2026-05-08T21:01:26.545Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/29/fe1aebec2ce57ab985a9c382bded1124431f85078113aa222c5d278430d4/propcache-0.5.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:583c19759d9eec1e5b69e2fbef36a7d9c326041be9746cb822d335c8cedc2979", size = 63300, upload-time = "2026-05-08T21:01:27.937Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/18/2334b26768b6c82be8c69e83671b767d5ef426aa09b0cba6c2ea47816774/propcache-0.5.2-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d0326e2e5e1f3163fa306c834e48e8d490e5fae607a097a40c0648109b47ba80", size = 64208, upload-time = "2026-05-08T21:01:29.484Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/76/7f1bfd6afff4c5e38e36a3c6d68eb5f4b7311ea80baf693db78d95b603c4/propcache-0.5.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e00820e192c8dbebcafb383ebbf99030895f09905e7a0eb2e0340a0bcc2bc825", size = 61633, upload-time = "2026-05-08T21:01:31.068Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/46/b3ff8aba2b4953a3e50de2cf72f1b5748b8eca93b15f3dc2c84339084c09/propcache-0.5.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c66afea89b1e43725731d2004732a046fe6fe955d51f952c3e95a7314a284a39", size = 61724, upload-time = "2026-05-08T21:01:32.374Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/01/814cfcafbcff954f94c01cf30e097ddc88a076b5440fbcf4570753437d40/propcache-0.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d4dc37dec6c6cdad0b57881a5658fd14fbf53e333b1a86cf86559f190e1d9ec4", size = 60069, upload-time = "2026-05-08T21:01:33.67Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/5c6f7622d510cc666a300687e06fd060c1a43361c0c9b20d284f06d8096a/propcache-0.5.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5570dbcc97571c15f68068e529c92715a12f8d54030e272d264b377e22bd17a5", size = 57099, upload-time = "2026-05-08T21:01:34.915Z" },
+    { url = "https://files.pythonhosted.org/packages/55/27/9cb0b4c679124085327957d42521c99dba04c88c90c3e55a6f0b633ebccc/propcache-0.5.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f814362777a9f841adddb200ecdf8f5cb1e5a3c4b7a86378edbd6ccb26edd702", size = 63391, upload-time = "2026-05-08T21:01:36.231Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9d/7258aaa5bdf60fc6f27591eef6fe52768cb0beda7140be477c8b12c9794a/propcache-0.5.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:196913dea116aeb5a2ba95af4ddcb7ea85559ae07d8eee8751688310d09168c3", size = 61626, upload-time = "2026-05-08T21:01:37.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/41c602003e8a9b16fe1e7eadf62c7bfba9d5474370b24200bf48b315f45f/propcache-0.5.2-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6e7b8719005dd1175be4ab1cd25e9b98659a5e0347331506ec6760d2773a7fb5", size = 64781, upload-time = "2026-05-08T21:01:38.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f3/38e66b1856e9bd079deea015bc4a55f7767c0e4db2f7dcf69e7e680ba4ce/propcache-0.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:51f96d685ab16e88cab128cd37a52c5da540809c8b879fa047731bfcb4ad35a4", size = 62570, upload-time = "2026-05-08T21:01:40.415Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ca/bbfe9b910ce57dde8bb4876b4520fc02a4e89497c10de26be936758a3aaa/propcache-0.5.2-cp314-cp314-win32.whl", hash = "sha256:cc6fc3cc62e8501d3ed62894425040d2728ecddb1ed072737a5c70bd537aa9f0", size = 39436, upload-time = "2026-05-08T21:01:41.654Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d2/45c9defbaa1ea297035d9d4cce9e8f80daafbf19319c6007f157c6256ea9/propcache-0.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:81e3a30b0bb60caa22033dd0f8a3618d1d67356212514f62c57db75cb0ef410c", size = 42373, upload-time = "2026-05-08T21:01:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/44/68/9ea5103f41d5217d7d6ec24db90018e23aebec070c3f9a6e54d12b841fd8/propcache-0.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:0d2c9bf8528f135dbb805ce027567e09164f7efa51a2be07458a2c0420f292d0", size = 38554, upload-time = "2026-05-08T21:01:44.336Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/81/fadf555f42d3b762eea8a53950b0489fdc0aa9da5f8ed9e10ce0a4e01b48/propcache-0.5.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4bc8ff1feffc6a61c7002ffe84634c41b822e104990ae009f44a0834430070bb", size = 99395, upload-time = "2026-05-08T21:01:45.883Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/c9/c61e134a686949cf7971af3a390148b1156f7be81c73bc0cd12c873e2d48/propcache-0.5.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:79aa3ff0a9b566633b642fa9caf7e21ed1c13d6feca718187873f199e1514078", size = 56653, upload-time = "2026-05-08T21:01:47.307Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/73/daf935ea7048ddd7ec8eec5345b4a40b619d2d178b3c0a0900796bc3c794/propcache-0.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1b31822f4474c4036bae62de9402710051d431a606d6a0f907fec79935a071aa", size = 56914, upload-time = "2026-05-08T21:01:48.573Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9f/aba959b435ea18617edd7cf0a7ad0b9c574b8fc7e3d2cd55fb59cb255d33/propcache-0.5.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13fef48778b5a2a756523fdb781326b028ca75e32858b04f2cdd19f394564917", size = 62567, upload-time = "2026-05-08T21:01:49.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a1/859942de9a791ff42f6141736f5b37749b8f53e65edfa49638c67dd67e6a/propcache-0.5.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8b73ab70f1a3351fbc71f663b3e645af6dd0329100c353081cf69c37433fc6fe", size = 65542, upload-time = "2026-05-08T21:01:51.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/61/315bc0fd6c0fc7f80a528b8afd209e5fc4a875ea79571b91b8f50f442907/propcache-0.5.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5538d2c13d93e4698af7e092b57bc7298fd35d1d58e656ae18f23ee0d0378e03", size = 66845, upload-time = "2026-05-08T21:01:52.539Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f7/9f8122e3132e8e354ac41975ef8f1099be7d5a16bc7ae562734e993665c0/propcache-0.5.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd645f03898405cabe694fb8bc35241e3a9c332ec85627584fe3de201452b335", size = 63985, upload-time = "2026-05-08T21:01:53.847Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/54/c317819ec157cbf6f35df9df9657a6f82daf34d5faf15948b2f639c2192e/propcache-0.5.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a473b3440261e0c60706e732b2ed2f517857344fc21bf48fdfe211e2d98eb285", size = 63999, upload-time = "2026-05-08T21:01:55.179Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/56/387e3f7dfce0a9233df41fb888aa1c30222cb4bbbf09537c02dd9bd85fe2/propcache-0.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7afa37062e6650640e932e4cc9297d81f9f42d9944029cc386b8247dea4da837", size = 62779, upload-time = "2026-05-08T21:01:57.489Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9c/596784cb5824ed61ee960d3f8655a3f0993e107c6e98ab6c818b7fb92ccb/propcache-0.5.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:8a90efd5777e996e42d568db9ac740b944d691e565cbfd31b2f7832f9184b2b8", size = 59796, upload-time = "2026-05-08T21:01:58.736Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/3d/1a6cfa1726a48542c1e8784a0761421476a5b68e09b7f36bf95eb954aaba/propcache-0.5.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:f19bb891234d72535764d703bfed1153cc34f4214d5bd7150aee1eec9e8f4366", size = 66023, upload-time = "2026-05-08T21:02:00.228Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0e/05fd6990369477076e4e280bcb970de760fddf0161a46e988bc95f7940ec/propcache-0.5.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:32775082acd2d807ee3db715c7770d38767b817870acfa08c29e057f3c4d5b56", size = 64448, upload-time = "2026-05-08T21:02:01.888Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/86/5f8da315a4309c62c10c0b2516b17492d5d3bbe1bb862b96604db67e2a37/propcache-0.5.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9282fb1a3bccd038da9f768b927b24a0c753e466c086b7c4f3c6982851eefb2d", size = 67329, upload-time = "2026-05-08T21:02:03.484Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d3/3368efe79ab21f0cdf86ef49895811c9cc933131d4cde1f28a624e22e712/propcache-0.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc49723e2f60d6b32a0f0b08a3fd6d13203c07f1cd9566cfce0f12a917c967a2", size = 65172, upload-time = "2026-05-08T21:02:04.745Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/07/127e8b0bacfb325396196f9d976a22453049b89b9b2b08477cc3145faa44/propcache-0.5.2-cp314-cp314t-win32.whl", hash = "sha256:2d7aa89ebca5acc98cba9d1472d976e394782f587bad6661003602a619fd1821", size = 43813, upload-time = "2026-05-08T21:02:06.025Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
 ]
 
 [[package]]
@@ -603,6 +872,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -780,6 +1063,21 @@ wheels = [
 ]
 
 [[package]]
+name = "stytch"
+version = "15.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/dc/2cc6554d5ae8e1fd15f1b48342049a614b801fc7c714ac5fb394a3a2f54a/stytch-15.3.0.tar.gz", hash = "sha256:f5e170c0dbb797541f80ef7e4dedcad1ed4585d3afbaa3cd3392dcd2d6245c78", size = 182114, upload-time = "2026-06-24T19:41:29.485Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/69/2d2ccb125ce97cded25aae0dc20fc003af61f76852ce0557e8030be4d0f3/stytch-15.3.0-py3-none-any.whl", hash = "sha256:6deba2fe298de66481f1c7287021268c556ba328b1c0e5b7de78ac895b62f0b6", size = 310625, upload-time = "2026-06-24T19:41:28.366Z" },
+]
+
+[[package]]
 name = "testcontainers"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
@@ -891,4 +1189,52 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
     { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
     { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.24.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/33/ebe9e3d1f86c7a0b51094c0a146392045ca1631d2664889539dec8088a33/yarl-1.24.5.tar.gz", hash = "sha256:e81b83143bee16329c23db3c1b2d82b29892fcbcb849186d2f6e98a5abe9a57f", size = 228679, upload-time = "2026-07-20T02:07:45.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/08/5f3085fef9564217074db9dd8573de1795bc82cde61a7ad10b6a7234a569/yarl-1.24.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2729fcfc4f6a596fb0c50f32090400aa9367774ac296a00387e65098c0befa76", size = 135680, upload-time = "2026-07-20T02:06:33.273Z" },
+    { url = "https://files.pythonhosted.org/packages/98/35/ba9436e579bd48a8801f2021d842d9ab4994c26e4c7dd3a4c1f1bcb57a9e/yarl-1.24.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ff330d3c30db4eb6b01d79e29d2d0b407a7ecad39cfd9ec993ece57396a2ec0d", size = 97395, upload-time = "2026-07-20T02:06:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a9/a07f76f3c44e02b25cc743af5ef93eef27f7013eadca770451b6a6ccb5db/yarl-1.24.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e42d75862735da90e7fc5a7b23db0c976f737113a54b3c9777a9b665e9cbff75", size = 97223, upload-time = "2026-07-20T02:06:37.216Z" },
+    { url = "https://files.pythonhosted.org/packages/77/f7/a9a1d6fa7dd9e388f95b30f6ad3ec4e285f6c8f61f44ce16070c3fcfe414/yarl-1.24.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a3732e66413163e72508da9eff9ce9d2846fde51fae45d3605393d3e6cd303e9", size = 108777, upload-time = "2026-07-20T02:06:39.292Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/44/e0b86c302471fabd6f02808ecf2ac52b8412b624787849d4bf2cdb466f6f/yarl-1.24.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5b8ee53be440a0cffc991a27be3057e0530122548dbe7c0892df08822fce5ede", size = 103119, upload-time = "2026-07-20T02:06:41.456Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/16/9c16d180bf8faaf223225eb50e1245870ff1ae0e302a27153988e65c51fd/yarl-1.24.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:af3aefa655adb5869491fa907e652290386800ae99cc50095cba71e2c6aefdca", size = 116471, upload-time = "2026-07-20T02:06:43.696Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8d/b219b9df28a02ce95cfbdd41d2f7caa5669d0ff979c1c9975697145e33c5/yarl-1.24.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2120b96872df4a117cde97d270bac96aea7cc52205d305cf4611df694a487027", size = 115974, upload-time = "2026-07-20T02:06:45.874Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e8/f20557aca240d88e69850ad1ee91756821d094bb1310565c04d25c6682a2/yarl-1.24.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:66410eb6345d467151934b49bfa70fb32f5b35a6140baa40ad97d6436abea2e9", size = 110830, upload-time = "2026-07-20T02:06:47.852Z" },
+    { url = "https://files.pythonhosted.org/packages/db/18/199b85109a53eeca64ee19c9cca228287e8e4ab0cc1a09b28f530e65cce0/yarl-1.24.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4af7b7e1be0a69bee8210735fe6dcfc38879adfac6d62e789d53ba432d1ffa41", size = 110054, upload-time = "2026-07-20T02:06:49.84Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2f/ed28147f8cd7f48c49367c90713b30a555284b6105a6a56f3a05568da795/yarl-1.24.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa139875ff98ab97da323cfadfaff08900d1ad42f1b5087b0b812a55c5a06373", size = 108312, upload-time = "2026-07-20T02:06:51.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/c5/55e16ae0a5c227cea8df1c6871ba57d614a34243146c05729caf2a1bd9c5/yarl-1.24.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:0055afc45e864b92729ac7600e2d102c17bef060647e74bca75fa84d66b9ff36", size = 103662, upload-time = "2026-07-20T02:06:54.061Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/ea/dbd7c2caec459c9a426f18b02688ecbfb58620d0f6a3422d24769fbaf8ab/yarl-1.24.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f0e466ed7511fe9d459a819edbc6c2585c0b6eabde9fa8a8947552468a7a6ef0", size = 116090, upload-time = "2026-07-20T02:06:56.015Z" },
+    { url = "https://files.pythonhosted.org/packages/06/84/39ce4ce3059e07fece5fbdbee8c4053406af9aca911ce9fa5f8548aab6af/yarl-1.24.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f141474e85b7e54998ec5180530a7cda99ab29e282fa50e0756d89981a9b43c5", size = 109523, upload-time = "2026-07-20T02:06:57.926Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8b/71ff44137b405c64a7788075669c24010019f57a7464b78c3a6cbee539d9/yarl-1.24.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:e2935f8c39e3b03e83519292d78f075189978f3f4adc15a78144c7c8e2a1cba5", size = 116084, upload-time = "2026-07-20T02:06:59.868Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c0/423078fdd4042e1862c11f0ffd977a0ffa393783c12bee94685923bc189e/yarl-1.24.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9d1216a7f6f77836617dba35687c5b78a4170afc3c3f18fc788f785ba26565c4", size = 111006, upload-time = "2026-07-20T02:07:01.907Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/52/6daa2ee9d95e5c98b8128f8df91eb692eb423ab274b8cf08db52152fad26/yarl-1.24.5-cp314-cp314-win_amd64.whl", hash = "sha256:5ba4f78df2bcc19f764a4b26a8a4f5049c110090ad5825993aacb052bf8003ad", size = 99215, upload-time = "2026-07-20T02:07:03.852Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0e/464a847d7359e0da75dd9fc5c1d1aa35d0159ea31e5f8e66a3c1c29ff3d0/yarl-1.24.5-cp314-cp314-win_arm64.whl", hash = "sha256:9e4e16c73d717c5cf27626c524d0a2e261ad20e46932b2670f64ad5dde23e26f", size = 94566, upload-time = "2026-07-20T02:07:06.074Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/55/e03acc4446772660bc335e86e41ef31e4d0d838fd641531a11a5ee33b493/yarl-1.24.5-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e1ae548a9d901adca07899a4147a7c826bbcc06239d3ce9a59f57886a28a4c88", size = 142533, upload-time = "2026-07-20T02:07:08.284Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/71/4acd3a1fc7cf14345cdb302665ecd2097f62c365b4f14ca17d4f37775cf9/yarl-1.24.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ff405d91509d88e8d44129cd87b18d70acd1f0c1aeabd7bc3c46792b1fe2acba", size = 100776, upload-time = "2026-07-20T02:07:10.197Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/cfb76b7fe99686db264bff829779a539d923e7564ffd7ef18da6c54c3774/yarl-1.24.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:47e98aab9d8d82ff682e7b0b5dded33bf138a32b817fcf7fa3b27b2d7c412928", size = 100913, upload-time = "2026-07-20T02:07:12.357Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3f/7116e782992abbd4fb6948488aec72078895e929a23078290739e8396fce/yarl-1.24.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f0a658a6d3fafee5c6f63c58f3e785c8c43c93fbc02bf9f2b6663f8185e0971f", size = 106507, upload-time = "2026-07-20T02:07:14.173Z" },
+    { url = "https://files.pythonhosted.org/packages/33/90/d4d2d73ee78229cc889872eb8e085d8f5c6f51abdb178409fd9b23cf74fd/yarl-1.24.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4377407001ca3c057773f44d8ddd6358fa5f691407c1ba92210bd3cf8d9e4c95", size = 99219, upload-time = "2026-07-20T02:07:16.019Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/fa/a6df1a9bccd644eec00abee0dff4277416222cec435330fd1f2858523ec1/yarl-1.24.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7c0494a31a1ac5461a226e7947a9c9b78c44e1dc7185164fa7e9651557a5d9bc", size = 111804, upload-time = "2026-07-20T02:07:18.141Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9e/7b2a1f4bcc20e9447156dd2b1c4d01f70d9df0759025ee7d09a84ffae134/yarl-1.24.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a7cff474ab7cd149765bb784cf6d78b32e18e20473fb7bda860bce98ab58e9da", size = 110943, upload-time = "2026-07-20T02:07:20.06Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ff/22c92affb0f9b623ca753d27d968b5625b868f12c6378d049d55ae247643/yarl-1.24.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbb833ccacdb5519eff9b8b71ee618cc2801c878e77e288775d77c3a2ced858a", size = 108251, upload-time = "2026-07-20T02:07:22.217Z" },
+    { url = "https://files.pythonhosted.org/packages/45/44/5769b96298c1e195fb412997b6090af2a84105cf59c17613558a2d011d1f/yarl-1.24.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:82f75e05912e84b7a0fe57075d9c59de3cb352b928330f2eb69b2e1f54c3e1f0", size = 106025, upload-time = "2026-07-20T02:07:24.083Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/40/009e8e791fd9762c0e1567e69248acb4f49064597e1680874c16dd8bb798/yarl-1.24.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:16a2f5010280020e90f5330257e6944bc33e73593b136cc5a241e6c1dc292498", size = 106573, upload-time = "2026-07-20T02:07:26.248Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c6/b7480578f8a0a80946f36ad6df547ecec704f9ba69d2de60f8aa6f1c1cbf/yarl-1.24.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:ffcd54362564dc1a30fb74d8b8a6e5a6b11ebd5e27266adc3b7427a21a6c9104", size = 100751, upload-time = "2026-07-20T02:07:28.098Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/27/4476f3360b91a48c5cf125e91f59a3bd35299d84a431a258d57f5977bb11/yarl-1.24.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0465ec8cedc2349b97a6b595ace64084a50c6e839eca40aa0626f38b8350e331", size = 111643, upload-time = "2026-07-20T02:07:30.88Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4b/5cdd3e5ee944e8af31e52f6cd3d3af5fd7b937e036ccbbba2c9ffebede95/yarl-1.24.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:4db9aecb141cb7a5447171b57aa1ed3a8fee06af40b992ffc31206c0b0121550", size = 106312, upload-time = "2026-07-20T02:07:33.06Z" },
+    { url = "https://files.pythonhosted.org/packages/18/86/f406b0c2a6f99575de2da671ef47aa06f89a5be83a27a46971c3b86cecdb/yarl-1.24.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:f540c013589084679a6c7fac07096b10159737918174f5dfc5e11bf5bca4dfe6", size = 110379, upload-time = "2026-07-20T02:07:35.155Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6c/9f3adfbd3b30b4fa0f7ccb3a83eba2c1152d3fff554d535e640ba0f7ba2b/yarl-1.24.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a61834fb15d81322d872eaafd333838ae7c9cea84067f232656f75965933d047", size = 108497, upload-time = "2026-07-20T02:07:37.35Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/37/91eb2e5ca883a529c1b390348a74cd9fc0512171727f547ce70bfe02be5c/yarl-1.24.5-cp314-cp314t-win_amd64.whl", hash = "sha256:5c88e5815a49d289e599f3513aa7fde0bc2092ff188f99c940f007f90f53d104", size = 102450, upload-time = "2026-07-20T02:07:39.578Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f4/ed5c402ac8fde4403ed3366c2716bfddc8a6677ebd59f3d62772cc7fe468/yarl-1.24.5-cp314-cp314t-win_arm64.whl", hash = "sha256:cf139c02f5f23ef6532040a30ff662c00a318c952334f211046b8e60b7f17688", size = 97222, upload-time = "2026-07-20T02:07:41.55Z" },
+    { url = "https://files.pythonhosted.org/packages/61/02/962c1cbfc401a30c1d034dc67ff395f64b52302c6d62de556c1fca99acc0/yarl-1.24.5-py3-none-any.whl", hash = "sha256:a33700d13d9b7d84fd10947b09ff69fb9a792e519c8cb9764a3ca70baa6c23a7", size = 58612, upload-time = "2026-07-20T02:07:43.461Z" },
 ]


### PR DESCRIPTION
Closes #20. Linear: LAV-37 · LAV-38 · LAV-39 · LAV-40 (*P6 — EE (Stytch)* project).

## What

The EE managed-identity path, slotted entirely behind existing abstractions — **no resource route changes**, OSS behavior untouched.

### Backend (lane B1)
- `app/auth/stytch/` — `StytchVerifier` seam: SDK fully isolated; provider/route/tests never see Stytch types; unit-injectable fake (no network in any test)
- `StytchProvider(AuthProvider)` — verifies the Stytch session cookie, then resolves the **mapped ACTIVE LAVS user** (verified email → users table); disabled/unmapped/pending → not-me
- `POST /auth/stytch/callback {stytch_token}` — verify → domain-allowlist check → email-mapped upsert (pending→activated; stytch-born users get an unusable random argon2 hash) → normal server-side session + `lavs_session` cookie **byte-identical** to `/auth/login` (shared `_set_session_cookie`); every failure is the same generic 401 (no enumeration, no 404 fingerprint when disabled)
- `AuthMode.STYTCH` honored **iff** `LAVS_EDITION=ee` (G-P6c/d); OSS parsing byte-identical
- `/meta` gains `stytch_public_token` (publishable only, EE only); OSS body byte-identical via `response_model_exclude_none`

### Frontend (lane F1)
- `stytch-login.tsx` — lazy `import('@stytch/vanilla-js')` (SDK never enters the OSS bundle; separate chunk), prebuilt widget with magic links + Google/GitHub OAuth (G-P6e), token from `/meta` with `VITE_STYTCH_PUBLIC_TOKEN` fallback (G-P6f)
- `stytchCallback` typed client fn; `completeStytchLogin` promotes the principal through the same path as `login()`
- `LoginForm`: stytch branch replaces "coming soon"; mixed-mode (password + stytch) layout; apikey/none branches unchanged

## Security gate (B)
First pass **failed** with 3 HIGH findings; all fixed and adversarially re-verified:
1. Unverified-email fallback (account-takeover vector) → verified-emails-only, fail closed
2. Direct Stytch-cookie provider bypassed the users table / disabled-account control → provider now requires a mapped ACTIVE LAVS row
3. Callback skipped `LAVS_ALLOWED_EMAIL_DOMAINS` → allowlist enforced (first-sight *and* existing users, generic 401)
Plus: first-sight insert race absorbed (DuckDB/psycopg unique-violation → adopt winner), StytchError telemetry without token, token never logged/persisted.

## Gates
- **A (enforcement):** PASS — 5 MINOR, all fixed
- **B (security):** PASS after debug pass (retry 1/2), adversarial re-check confirmed all fixes
- **C (integration):** BE **466 pytest** + ruff + format + pyright · FE **118 vitest** + typecheck + lint + build · **Playwright 4/4** (OSS login regression-free)

## Deps (flagged, G-P6a)
`stytch` 15.3.0 (BE runtime) · `@stytch/vanilla-js` 6.0.11 (FE, lazy chunk)

No live Stytch tenant required (G-P6b): provider-boundary fakes + MSW; real-tenant manual smoke post-merge when credentials exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)