### PR TITLE
feat(security): P8 — v1 hardening (pre-tag): non-root container, chart auth wiring, rate limiting, caps (LAV-48..52)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Keep the build context minimal: only pyproject.toml, uv.lock, README.md and app/
+# are COPY'd, but the whole context is still sent to the daemon.
+.git
+.venv
+node_modules
+frontend
+tests
+docs
+dist
+build
+coverage
+htmlcov
+.coverage
+.pytest_cache
+.ruff_cache
+**/__pycache__
+**/*.pyc
+# Local DuckDB files must never ship inside the image (app/test.db lives in the app package dir)
+**/*.db
+**/*.db.wal
+**/*.duckdb
+.claude
+.github
+helm
+scratch

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -32,3 +32,36 @@ jobs:
         run: uv run pyright app
       - name: Run tests
         run: uv run pytest -q
+
+  dependency-audit:
+    runs-on: ubuntu-latest
+    # Blocking gate. click was bumped to >= 8.3.3 (PYSEC-2026-2132) via the
+    # pyproject constraint-dependencies floor, so the audit runs clean.
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Install Python 3.14
+        run: uv python install 3.14
+      - name: Audit locked runtime dependencies with pip-audit
+        # Explicit bash adds -o pipefail: a failed `uv export` must fail the
+        # gate, not hand pip-audit an empty stdin that passes vacuously.
+        shell: bash
+        run: uv export --format requirements-txt --no-dev --no-emit-project | uvx pip-audit -r /dev/stdin --strict
+
+  frontend-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Audit production dependencies with pnpm
+        working-directory: frontend/ui
+        env:
+          CI: "true"
+        run: pnpm audit --prod --audit-level high

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,35 @@
-FROM docker.io/python:3.14-slim-bookworm
+# Base pinned by digest (LAV-52/L-4). Digest resolved from the local image cache
+# (docker images --digests) — daemon-side pulls to Docker Hub are IPv6-blackholed,
+# so this is the verified repo digest of python:3.14-slim-bookworm as cached.
+FROM docker.io/python:3.14-slim-bookworm@sha256:4ff4b92a68355dbdb52584ab3391dff8d371a61d4e063468bfd0130e3189c6d9
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+# uv binary, also pinned by digest (resolved from the local cache of ghcr.io/astral-sh/uv:latest).
+COPY --from=ghcr.io/astral-sh/uv@sha256:99ea34acedc870ba4ad11a1f540a1c04267c9f30aadc465a94406f52dfda2c36 /uv /bin/uv
+
+# Non-root runtime user (LAV-48/M-1). Fixed uid/gid 10001 so Kubernetes
+# runAsNonRoot/fsGroup defaults in helm/lavs/values.yaml line up with the image.
+RUN groupadd --gid 10001 lavs \
+    && useradd --uid 10001 --gid 10001 --create-home --shell /usr/sbin/nologin lavs
 
 WORKDIR /app
 
 COPY pyproject.toml uv.lock README.md ./
 COPY app ./app
 
-RUN uv sync --frozen --no-dev
+# Install deps, then hand the whole tree to the runtime user: the embedded DuckDB
+# writes its file (and WAL) under the app package dir (/app/app/test.db by default,
+# see app/configurations/root_dir.py), and `uv run` needs the venv writable.
+RUN uv sync --frozen --no-dev \
+    && chown -R lavs:lavs /app
+
+USER 10001:10001
+ENV HOME=/home/lavs
 
 EXPOSE 8080
+
+# Container-level liveness (LAV-52). curl is not in the slim image; python is.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD ["python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8080/health', timeout=4).status == 200 else 1)"]
 
 # --no-dev keeps the runtime env in sync with the build (no pyright/ruff re-download on cold start)
 CMD ["uv", "run", "--no-dev", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/app/auth/session/session_service.py
+++ b/app/auth/session/session_service.py
@@ -6,13 +6,31 @@ mints one, stores only its SHA-256 hash together with a TTL-derived
 present the raw token, which is re-hashed and matched against the stored hash;
 an expired row never matches, so a lapsed cookie authenticates nobody. Every
 statement binds its values through ``?`` placeholders.
+
+Wall-clock time is always taken in UTC (:func:`_utc_now`) and bound as a
+timezone-naive value, because the ``sessions`` columns are naive ``TIMESTAMP``
+on both DuckDB and PostgreSQL: a naive-UTC bind round-trips verbatim on both
+backends, whereas a tz-aware bind would be cast through the session time zone.
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from app.auth.token_service import TokenService
 from app.connections.db_session import DbSession
 from app.models.types.ulid_id import new_ulid
+
+
+def _utc_now() -> datetime:
+    """Return the current UTC wall-clock time as a naive ``datetime``.
+
+    Computed as :func:`datetime.now` in UTC with ``tzinfo`` stripped so the
+    value binds into the naive ``TIMESTAMP`` columns identically on DuckDB and
+    PostgreSQL, independent of the host or database session time zone.
+
+    Returns:
+        The current instant in UTC, timezone-naive.
+    """
+    return datetime.now(UTC).replace(tzinfo=None)
 
 
 class SessionService:
@@ -41,7 +59,7 @@ class SessionService:
         """
         token = self._token_service.generate_token()
         token_hash = self._token_service.hash_token(token)
-        expires_at = datetime.now() + timedelta(seconds=ttl_seconds)
+        expires_at = _utc_now() + timedelta(seconds=ttl_seconds)
         conn.execute(
             "INSERT INTO sessions (id, user_id, token_hash, expires_at) VALUES (?, ?, ?, ?)",
             [new_ulid(), user_id, token_hash, expires_at],
@@ -62,7 +80,7 @@ class SessionService:
         token_hash = self._token_service.hash_token(token)
         row = conn.execute(
             "SELECT user_id FROM sessions WHERE token_hash = ? AND expires_at > ?",
-            [token_hash, datetime.now()],
+            [token_hash, _utc_now()],
         ).fetchone()
         if row is None:
             return None

--- a/app/auth/signup/signup_service.py
+++ b/app/auth/signup/signup_service.py
@@ -8,6 +8,9 @@ Security posture:
   nothing about account existence (no enumeration).
 """
 
+import duckdb
+import psycopg.errors
+
 from app.auth.auth_settings import AuthSettings
 from app.auth.password_hasher import PasswordHasher
 from app.auth.signup.verification_email import VerificationEmail
@@ -22,6 +25,10 @@ from app.errors.domain_not_allowed_error import DomainNotAllowedError
 from app.mail.mailer import Mailer
 from app.models.requests.signup_model import SignupModel
 from app.models.types.ulid_id import new_ulid
+
+# The single conflict message for a taken address — identical on the pre-check
+# and insert-race paths so the response never reveals which one fired.
+_DUPLICATE_EMAIL_MESSAGE = "This email address cannot be registered."
 
 
 class SignupService:
@@ -90,14 +97,21 @@ class SignupService:
 
         password_hash = self._password_hasher.hash_password(model.password)
         user_id = new_ulid()
-        await self._users.create_user(
-            conn,
-            user_id=user_id,
-            email=email,
-            password_hash=password_hash,
-            status=UserStatus.PENDING,
-            edition=settings.edition(),
-        )
+        try:
+            await self._users.create_user(
+                conn,
+                user_id=user_id,
+                email=email,
+                password_hash=password_hash,
+                status=UserStatus.PENDING,
+                edition=settings.edition(),
+            )
+        except duckdb.ConstraintException, psycopg.errors.UniqueViolation:
+            # A concurrent sign-up for the same address won the insert race
+            # after our availability pre-check; surface the same 409 as the
+            # pre-check path. ``from None``: the driver's message may embed row
+            # values and must not chain into the generic conflict response.
+            raise ConflictError(message=_DUPLICATE_EMAIL_MESSAGE) from None
 
         raw_token = self._token_service.generate_token()
         await self._verification_tokens.issue(
@@ -145,4 +159,4 @@ class SignupService:
         """
         existing = await self._users.get_user_by_email(conn, email)
         if existing is not None:
-            raise ConflictError(message="This email address cannot be registered.")
+            raise ConflictError(message=_DUPLICATE_EMAIL_MESSAGE)

--- a/app/auth/signup/verification_token_repository.py
+++ b/app/auth/signup/verification_token_repository.py
@@ -4,14 +4,29 @@ Tokens are stored **only** as their SHA-256 hash (the raw token is never
 persisted), carry a Python-computed expiry, and are single-use: a consumed row is
 stamped with ``consumed_at`` and never matched again. Every statement binds its
 values through ``?`` placeholders — never string interpolation. Wall-clock time
-is taken from the process clock (:func:`datetime.now`) and bound as a parameter,
-matching :class:`~app.auth.session.session_service.SessionService` so expiry is
-expressed identically — and dialect-neutrally — across DuckDB and PostgreSQL.
+is always taken in UTC (:func:`_utc_now`) and bound as a timezone-naive value,
+matching :class:`~app.auth.session.session_service.SessionService`: the
+``email_verification_tokens`` columns are naive ``TIMESTAMP`` on both DuckDB and
+PostgreSQL, so a naive-UTC bind round-trips verbatim on both backends, whereas a
+tz-aware bind would be cast through the session time zone.
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from app.connections.db_session import DbSession
+
+
+def _utc_now() -> datetime:
+    """Return the current UTC wall-clock time as a naive ``datetime``.
+
+    Computed as :func:`datetime.now` in UTC with ``tzinfo`` stripped so the
+    value binds into the naive ``TIMESTAMP`` columns identically on DuckDB and
+    PostgreSQL, independent of the host or database session time zone.
+
+    Returns:
+        The current instant in UTC, timezone-naive.
+    """
+    return datetime.now(UTC).replace(tzinfo=None)
 
 
 class VerificationTokenRepository:
@@ -26,9 +41,10 @@ class VerificationTokenRepository:
     ) -> None:
         """Insert a verification-token row with a Python-computed expiry.
 
-        The expiry is computed in Python (``datetime.now() + ttl``) and bound as
-        a parameter rather than derived with an in-SQL interval expression, so the
-        statement parses identically on DuckDB and PostgreSQL.
+        The expiry is computed in Python (UTC now + ttl, bound naive) rather
+        than derived with an in-SQL interval expression, so the statement parses
+        identically on DuckDB and PostgreSQL and never depends on either
+        backend's session time zone.
 
         Args:
             conn: The live database session.
@@ -37,7 +53,7 @@ class VerificationTokenRepository:
             user_id: The id of the pending user the token verifies.
             ttl_seconds: The token lifetime, added to the clock for expiry.
         """
-        expires_at = datetime.now() + timedelta(seconds=ttl_seconds)
+        expires_at = _utc_now() + timedelta(seconds=ttl_seconds)
         conn.execute(
             "INSERT INTO email_verification_tokens "
             "(token_hash, user_id, expires_at, consumed_at) "
@@ -66,7 +82,7 @@ class VerificationTokenRepository:
             "FROM email_verification_tokens "
             "WHERE token_hash = ? AND consumed_at IS NULL "
             "AND expires_at > ?",
-            [token_hash, datetime.now()],
+            [token_hash, _utc_now()],
         ).fetchone()
 
     async def consume(self, conn: DbSession, token_hash: str) -> None:
@@ -78,5 +94,5 @@ class VerificationTokenRepository:
         """
         conn.execute(
             "UPDATE email_verification_tokens SET consumed_at = ? WHERE token_hash = ?",
-            [datetime.now(), token_hash],
+            [_utc_now(), token_hash],
         )

--- a/app/database/duckdb/ddl.sql
+++ b/app/database/duckdb/ddl.sql
@@ -60,6 +60,10 @@ CREATE TABLE IF NOT EXISTS users (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- expires_at / consumed_at on the two auth tables below are naive TIMESTAMP
+-- columns holding UTC instants: SessionService and VerificationTokenRepository
+-- compute time as datetime.now(UTC) with tzinfo stripped before binding, so
+-- values round-trip verbatim regardless of the host or session time zone.
 CREATE TABLE IF NOT EXISTS sessions (
     id VARCHAR PRIMARY KEY,
     user_id VARCHAR NOT NULL REFERENCES users(id),

--- a/app/database/postgres/ddl.sql
+++ b/app/database/postgres/ddl.sql
@@ -67,6 +67,10 @@ CREATE TABLE IF NOT EXISTS users (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- expires_at / consumed_at on the two auth tables below are naive TIMESTAMP
+-- columns holding UTC instants: SessionService and VerificationTokenRepository
+-- compute time as datetime.now(UTC) with tzinfo stripped before binding, so
+-- values round-trip verbatim regardless of the host or session time zone.
 CREATE TABLE IF NOT EXISTS sessions (
     id VARCHAR PRIMARY KEY,
     user_id VARCHAR NOT NULL REFERENCES users(id),

--- a/app/errors/error_code.py
+++ b/app/errors/error_code.py
@@ -16,5 +16,6 @@ class ErrorCode(StrEnum):
     UNAUTHORIZED = "unauthorized"
     FORBIDDEN = "forbidden"
     DOMAIN_NOT_ALLOWED = "domain_not_allowed"
+    RATE_LIMITED = "rate_limited"
     HTTP_ERROR = "http_error"
     INTERNAL_ERROR = "internal_error"

--- a/app/errors/handlers.py
+++ b/app/errors/handlers.py
@@ -24,6 +24,7 @@ _HTTP_STATUS_TO_CODE: dict[int, ErrorCode] = {
     status.HTTP_403_FORBIDDEN: ErrorCode.FORBIDDEN,
     status.HTTP_404_NOT_FOUND: ErrorCode.NOT_FOUND,
     status.HTTP_409_CONFLICT: ErrorCode.CONFLICT,
+    status.HTTP_429_TOO_MANY_REQUESTS: ErrorCode.RATE_LIMITED,
 }
 
 

--- a/app/errors/rate_limited_error.py
+++ b/app/errors/rate_limited_error.py
@@ -1,0 +1,19 @@
+"""Typed error for a rate-limited request (HTTP 429)."""
+
+from fastapi import status
+
+from app.errors.domain_error import DomainError
+from app.errors.error_code import ErrorCode
+
+
+class RateLimitedError(DomainError):
+    """Raised when a client exceeds the configured request rate.
+
+    Serializes to HTTP 429 with envelope code ``rate_limited``. Used by the
+    auth rate-limit middleware, which renders the envelope directly (user
+    middleware runs outside the exception-handler stack) but builds it from
+    this typed error so the shape stays identical to every other failure.
+    """
+
+    http_status: int = status.HTTP_429_TOO_MANY_REQUESTS
+    code: ErrorCode = ErrorCode.RATE_LIMITED

--- a/app/events/event_bus.py
+++ b/app/events/event_bus.py
@@ -8,16 +8,27 @@ created in the FastAPI lifespan and stored on ``app.state.event_bus``.
 Concurrency: all mutation of the subscriber registry happens in synchronous
 methods with no ``await`` between read and write, so the single-threaded event
 loop already serialises them; publishing uses :meth:`asyncio.Queue.put_nowait`
-on unbounded queues, which never blocks and so never yields mid-fan-out.
+(with synchronous drop-oldest eviction on overflow), which never blocks and so
+never yields mid-fan-out.
+
+Backpressure policy: each subscriber queue is bounded (:data:`QUEUE_MAXSIZE`).
+When a slow or stalled consumer lets its queue fill up, the oldest queued event
+is evicted to make room for the newest — the publisher never blocks and never
+raises. A consumer that missed events simply re-syncs the full state via the
+REST endpoints (SSE frames are notifications, not the source of truth), so
+dropping stale frames is safe.
 """
 
 import asyncio
 
 from app.events.domain_event import DomainEvent
 
+QUEUE_MAXSIZE = 256
+"""Per-subscriber queue bound; overflow evicts the oldest queued event."""
+
 
 class EventBus:
-    """Per-product fan-out of domain events to subscriber queues."""
+    """Per-product fan-out of domain events to bounded subscriber queues."""
 
     def __init__(self) -> None:
         """Create an event bus with no subscribers."""
@@ -26,15 +37,42 @@ class EventBus:
     async def publish(self, event: DomainEvent) -> None:
         """Deliver ``event`` to every queue subscribed to its product.
 
-        Delivery is non-blocking: each subscriber has an unbounded queue, so a
-        slow or disconnected consumer cannot stall the publisher. Products with
-        no subscribers are a no-op.
+        Delivery is non-blocking and never raises: each subscriber queue is
+        bounded, and when one is full the oldest queued event is dropped to
+        make room for this one (drop-oldest). A slow or disconnected consumer
+        therefore cannot stall the publisher; it re-syncs via REST after a
+        gap. Products with no subscribers are a no-op.
 
         Args:
             event: The domain event to fan out.
         """
         for queue in tuple(self._subscribers.get(event.product_id, ())):
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                self._evict_oldest_and_put(queue, event)
+
+    @staticmethod
+    def _evict_oldest_and_put(queue: asyncio.Queue[DomainEvent], event: DomainEvent) -> None:
+        """Drop the oldest queued event, then enqueue ``event``.
+
+        Runs synchronously with no ``await``, so no consumer can interleave
+        between the eviction and the put on the single-threaded event loop.
+        Both fallbacks are defensive: after evicting one item from a full
+        bounded queue the put cannot fail, and an empty queue cannot be full.
+
+        Args:
+            queue: The full subscriber queue to make room in.
+            event: The new event to enqueue after eviction.
+        """
+        try:
+            queue.get_nowait()
+        except asyncio.QueueEmpty:  # pragma: no cover - full queue is never empty
+            pass
+        try:
             queue.put_nowait(event)
+        except asyncio.QueueFull:  # pragma: no cover - room was just made above
+            pass
 
     def subscribe(self, product_id: str) -> asyncio.Queue[DomainEvent]:
         """Register and return a fresh queue for ``product_id``'s events.
@@ -46,9 +84,10 @@ class EventBus:
             product_id: The product whose events the caller wants.
 
         Returns:
-            A new unbounded queue that will receive that product's events.
+            A new bounded queue (:data:`QUEUE_MAXSIZE`) that will receive that
+            product's events; on overflow its oldest event is dropped.
         """
-        queue: asyncio.Queue[DomainEvent] = asyncio.Queue()
+        queue: asyncio.Queue[DomainEvent] = asyncio.Queue(maxsize=QUEUE_MAXSIZE)
         self._subscribers.setdefault(product_id, set()).add(queue)
         return queue
 

--- a/app/mail/capture_mailer.py
+++ b/app/mail/capture_mailer.py
@@ -1,5 +1,7 @@
 """An in-memory :class:`~app.mail.mailer.Mailer` that records sent messages."""
 
+from collections import deque
+
 from app.mail.captured_email import CapturedEmail
 from app.mail.mailer import Mailer
 
@@ -8,17 +10,34 @@ class CaptureMailer(Mailer):
     """A deterministic mail sink that stores sent messages in memory.
 
     This is the v1 email transport: instead of talking to an SMTP daemon it
-    appends every send to an in-memory list, so the sign-up/verify flow can be
-    driven end to end (retrieve the verification token straight from the last
-    captured message). A single instance is app-scoped on ``app.state.mailer``.
+    appends every send to an in-memory buffer, so the sign-up/verify flow can
+    be driven end to end (retrieve the verification token straight from the
+    last captured message). A single instance is app-scoped on
+    ``app.state.mailer``.
+
+    Memory bound: the buffer is a ring capped at ``max_messages`` entries
+    (100 by default) — when full, each new send silently evicts the oldest
+    capture, so a long-lived process can never grow the buffer without bound.
+    The read API (:meth:`messages`, :meth:`last_message`, :meth:`last_for`,
+    :meth:`clear`) is unchanged.
     """
 
-    def __init__(self) -> None:
-        """Initialise an empty capture buffer."""
-        self._messages: list[CapturedEmail] = []
+    _DEFAULT_MAX_MESSAGES: int = 100
+
+    def __init__(self, max_messages: int | None = None) -> None:
+        """Initialise an empty, bounded capture buffer.
+
+        Args:
+            max_messages: Ring-buffer capacity; the class default (100) when
+                omitted.
+        """
+        capacity = max_messages if max_messages is not None else self._DEFAULT_MAX_MESSAGES
+        self._messages: deque[CapturedEmail] = deque(maxlen=capacity)
 
     def send(self, to: str, subject: str, body: str) -> None:
-        """Record an email in the in-memory buffer.
+        """Record an email in the in-memory ring buffer.
+
+        When the buffer is at capacity the oldest capture is evicted.
 
         Args:
             to: The recipient address.
@@ -28,7 +47,7 @@ class CaptureMailer(Mailer):
         self._messages.append(CapturedEmail(to=to, subject=subject, body=body))
 
     def messages(self) -> tuple[CapturedEmail, ...]:
-        """Return every captured message in send order."""
+        """Return every retained message in send order (oldest first)."""
         return tuple(self._messages)
 
     def last_message(self) -> CapturedEmail | None:
@@ -43,7 +62,7 @@ class CaptureMailer(Mailer):
 
         Returns:
             The latest :class:`CapturedEmail` addressed to ``recipient``, or
-            ``None`` when none was sent.
+            ``None`` when none was sent (or it has been evicted by the ring).
         """
         for message in reversed(self._messages):
             if message.to == recipient:

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from app.mail.capture_mailer import CaptureMailer
 from app.openapi.app_metadata import AppMetadata
 from app.openapi.openapi_customizer import OpenApiCustomizer
 from app.routers import auth, components, events, meta, products, releases, timeline, versions
+from app.security.rate_limit_middleware import RateLimitMiddleware
 
 logger = logging.getLogger("lavs-api")
 
@@ -101,6 +102,12 @@ app = FastAPI(
     version=AppMetadata.version(),
 )
 register_error_handlers(app)
+
+# Per-IP rate limiting over the unauthenticated /auth/* bootstrap surface.
+# Always wired, but inert until LAVS_AUTH_RATE_LIMIT is set to a positive
+# value (default posture is disabled — see RateLimitSettings), so bare
+# TestClient suites and OSS quick-starts are unaffected out of the box.
+app.add_middleware(RateLimitMiddleware)
 
 
 @app.get("/")

--- a/app/models/requests/create_component_model.py
+++ b/app/models/requests/create_component_model.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from annotated_types import MinLen
+from annotated_types import MaxLen, MinLen
 
 from app.models.enums.component_kind import ComponentKind
 from app.models.requests.request_model import RequestModel
@@ -16,7 +16,7 @@ class CreateComponentModel(RequestModel):
     """
 
     product_id: UlidId
-    name: Annotated[str, MinLen(1)]
+    name: Annotated[str, MinLen(1), MaxLen(256)]
     kind: ComponentKind
 
     model_config = {

--- a/app/models/requests/create_product_model.py
+++ b/app/models/requests/create_product_model.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from annotated_types import MinLen
+from annotated_types import MaxLen, MinLen
 
 from app.models.requests.request_model import RequestModel
 
@@ -13,8 +13,8 @@ class CreateProductModel(RequestModel):
     See ``docs/design/API_CONTRACT.md`` §3.
     """
 
-    name: Annotated[str, MinLen(1)]
-    description: str | None = None
+    name: Annotated[str, MinLen(1), MaxLen(256)]
+    description: Annotated[str, MaxLen(4096)] | None = None
 
     model_config = {
         "json_schema_extra": {

--- a/app/models/requests/create_version_model.py
+++ b/app/models/requests/create_version_model.py
@@ -3,7 +3,7 @@
 import re
 from typing import Annotated
 
-from annotated_types import Ge
+from annotated_types import Ge, MaxLen
 from pydantic import computed_field, field_validator
 
 from app.models.requests.request_model import RequestModel
@@ -19,8 +19,8 @@ class CreateVersionModel(RequestModel):
     """
 
     component_id: UlidId
-    version: str
-    prerelease: str | None = None
+    version: Annotated[str, MaxLen(256)]
+    prerelease: Annotated[str, MaxLen(256)] | None = None
 
     @field_validator("version", mode="before")
     @classmethod

--- a/app/models/requests/cut_release_model.py
+++ b/app/models/requests/cut_release_model.py
@@ -1,5 +1,9 @@
 """Request body for cutting a release."""
 
+from typing import Annotated
+
+from annotated_types import MaxLen
+
 from app.models.requests.request_model import RequestModel
 
 
@@ -12,8 +16,8 @@ class CutReleaseModel(RequestModel):
     minor, starting from the product's configured base).
     """
 
-    label: str | None = None
-    notes: str | None = None
+    label: Annotated[str, MaxLen(256)] | None = None
+    notes: Annotated[str, MaxLen(4096)] | None = None
 
     model_config = {
         "json_schema_extra": {"examples": [{"label": "Aurora 5.1", "notes": "optional"}]}

--- a/app/models/requests/login_model.py
+++ b/app/models/requests/login_model.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from annotated_types import MinLen
+from annotated_types import MaxLen, MinLen
 from pydantic import field_validator
 
 from app.models.requests.request_model import RequestModel
@@ -18,8 +18,8 @@ class LoginModel(RequestModel):
     ``docs/design/API_CONTRACT.md`` §2.
     """
 
-    email: Annotated[str, MinLen(1)]
-    password: Annotated[str, MinLen(1)]
+    email: Annotated[str, MinLen(1), MaxLen(320)]
+    password: Annotated[str, MinLen(1), MaxLen(128)]
 
     @field_validator("email")
     @classmethod

--- a/app/models/requests/signup_model.py
+++ b/app/models/requests/signup_model.py
@@ -3,7 +3,7 @@
 import re
 from typing import Annotated
 
-from annotated_types import MinLen
+from annotated_types import MaxLen, MinLen
 from pydantic import field_validator
 
 from app.auth.signup.signup_policy import SignupPolicy
@@ -19,8 +19,8 @@ class SignupModel(RequestModel):
     :attr:`SignupPolicy.EMAIL_PATTERN`. See ``docs/design/API_CONTRACT.md`` §2.
     """
 
-    email: str
-    password: Annotated[str, MinLen(SignupPolicy.MIN_PASSWORD_LENGTH)]
+    email: Annotated[str, MaxLen(320)]
+    password: Annotated[str, MinLen(SignupPolicy.MIN_PASSWORD_LENGTH), MaxLen(128)]
 
     @field_validator("email")
     @classmethod

--- a/app/models/requests/stytch_callback_model.py
+++ b/app/models/requests/stytch_callback_model.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from annotated_types import MinLen
+from annotated_types import MaxLen, MinLen
 
 from app.models.requests.request_model import RequestModel
 
@@ -17,6 +17,6 @@ class StytchCallbackModel(RequestModel):
     The token is never logged or persisted.
     """
 
-    stytch_token: Annotated[str, MinLen(1)]
+    stytch_token: Annotated[str, MinLen(1), MaxLen(4096)]
 
     model_config = {"json_schema_extra": {"examples": [{"stytch_token": "WJtR5BCy38..."}]}}

--- a/app/models/requests/verify_model.py
+++ b/app/models/requests/verify_model.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from annotated_types import MinLen
+from annotated_types import MaxLen, MinLen
 
 from app.models.requests.request_model import RequestModel
 
@@ -15,6 +15,6 @@ class VerifyModel(RequestModel):
     ``docs/design/API_CONTRACT.md`` §2.
     """
 
-    token: Annotated[str, MinLen(1)]
+    token: Annotated[str, MinLen(1), MaxLen(256)]
 
     model_config = {"json_schema_extra": {"examples": [{"token": "Xy8f…opaque-url-safe-token"}]}}

--- a/app/security/api_key.py
+++ b/app/security/api_key.py
@@ -1,32 +1,22 @@
-"""API key authentication module for lavs API.
+"""API key configuration helpers for the lavs API.
 
-This module provides API key-based authentication for protecting routes.
-It supports optional authentication - when no API key is configured,
-all requests are allowed through.
+This module exposes the configured API key (if any) and whether API-key
+authentication is enabled. Request-time enforcement lives in
+:class:`~app.auth.providers.api_key_provider.ApiKeyProvider`, which reads the
+header and compares it against the configured key.
 """
 
-import logging
-from typing import Annotated
-
-from fastapi import Depends, HTTPException, status
-from fastapi.security import APIKeyHeader
-
 from app.security.api_key_settings import ApiKeySettings
-
-logger = logging.getLogger("lavs-api")
 
 # Settings object holding the fixed header/env-var names and providing the
 # runtime read of the configured key value.
 _settings = ApiKeySettings()
 
-# Names exposed for the FastAPI dependency and for callers/tests that need the
-# header and environment-variable names. These are derived from the settings
-# object rather than defined as bare literal constants.
+# Names exposed for callers/tests that need the header and environment-variable
+# names. These are derived from the settings object rather than defined as bare
+# literal constants.
 API_KEY_HEADER = _settings.header_name
 API_KEY_ENV_VAR = _settings.env_var_name
-
-# Header dependency for FastAPI
-api_key_header = APIKeyHeader(name=API_KEY_HEADER, auto_error=False)
 
 
 def get_configured_api_key() -> str | None:
@@ -46,50 +36,3 @@ def is_authentication_enabled() -> bool:
     """
     api_key = get_configured_api_key()
     return api_key is not None and api_key != ""
-
-
-async def get_api_key(api_key: Annotated[str | None, Depends(api_key_header)] = None) -> str:
-    """Validate the API key from the request header.
-
-    This dependency can be used to protect routes. When authentication
-    is disabled (no API key configured), any request is allowed through.
-
-    Args:
-        api_key: The API key from the request header, provided by FastAPI
-                 dependency injection.
-
-    Returns:
-        The validated API key, or empty string if auth is disabled.
-
-    Raises:
-        HTTPException: If authentication is enabled and the provided
-                       API key is invalid or missing.
-    """
-    # If no API key is configured, allow all requests (optional auth)
-    if not is_authentication_enabled():
-        logger.debug("Authentication disabled - allowing request")
-        return api_key if api_key is not None else ""
-
-    # Authentication is enabled - validate the API key
-    configured_key = get_configured_api_key()
-
-    if api_key is None:
-        logger.warning("API key missing in request")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"API key is required. Provide it in the {API_KEY_HEADER} header.",
-        )
-
-    if api_key != configured_key:
-        logger.warning("Invalid API key provided")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Invalid API key",
-        )
-
-    logger.debug("API key validated successfully")
-    return api_key
-
-
-# Type alias for dependency injection
-ApiKeyDep = Annotated[str, Depends(get_api_key)]

--- a/app/security/rate_limit_middleware.py
+++ b/app/security/rate_limit_middleware.py
@@ -1,0 +1,155 @@
+"""Pure-ASGI middleware applying the per-IP rate limit to ``/auth/*``."""
+
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from app.errors.error_detail import ErrorDetail
+from app.errors.error_envelope import ErrorEnvelope
+from app.errors.rate_limited_error import RateLimitedError
+from app.security.rate_limit_settings import RateLimitSettings
+from app.security.sliding_window_limiter import SlidingWindowLimiter
+
+
+class RateLimitMiddleware:
+    """Rate-limits the unauthenticated ``/auth/*`` bootstrap surface per IP.
+
+    Pure ASGI (no ``BaseHTTPMiddleware``) so streaming responses elsewhere in
+    the app (SSE) are never buffered. Only HTTP requests whose path sits under
+    ``/auth/`` are considered; every other path — including the resource
+    routes, which are protected by credentials rather than by this throttle —
+    passes straight through.
+
+    Settings are read from :class:`RateLimitSettings` **per request**, so the
+    limiter obeys environment changes at runtime and stays completely inert
+    (no counting, no memory growth) while disabled — which is the default
+    posture (``LAVS_AUTH_RATE_LIMIT`` unset or ``0``), keeping bare
+    ``TestClient`` suites unaffected.
+
+    On refusal the middleware renders the uniform error envelope itself:
+    ``add_middleware`` stacks run outside Starlette's exception middleware, so
+    raising :class:`RateLimitedError` here would never reach the registered
+    handlers. The response is built **from** the typed error, so status, code,
+    and shape stay identical to a handler-rendered envelope, plus a standard
+    ``Retry-After`` header.
+    """
+
+    _AUTH_PATH_PREFIX: str = "/auth/"
+    _FORWARDED_FOR_HEADER: bytes = b"x-forwarded-for"
+    _UNKNOWN_CLIENT_KEY: str = "unknown"
+    _RATE_LIMITED_MESSAGE: str = "too many requests"
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        settings: RateLimitSettings | None = None,
+        limiter: SlidingWindowLimiter | None = None,
+    ) -> None:
+        """Initialise the middleware.
+
+        Args:
+            app: The downstream ASGI application.
+            settings: The rate-limit settings; environment-backed when omitted.
+            limiter: The sliding-window limiter; a fresh one bounded by
+                ``settings.max_tracked_clients()`` when omitted.
+        """
+        self._app = app
+        self._settings = settings if settings is not None else RateLimitSettings()
+        self._limiter = (
+            limiter
+            if limiter is not None
+            else SlidingWindowLimiter(max_keys=self._settings.max_tracked_clients())
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Apply the limit to ``/auth/*`` HTTP requests; pass everything else.
+
+        Args:
+            scope: The ASGI connection scope.
+            receive: The ASGI receive callable.
+            send: The ASGI send callable.
+        """
+        if scope["type"] != "http" or not str(scope["path"]).startswith(self._AUTH_PATH_PREFIX):
+            await self._app(scope, receive, send)
+            return
+
+        if not self._settings.enabled():
+            await self._app(scope, receive, send)
+            return
+
+        key = self._client_key(scope)
+        admitted = self._limiter.allow(
+            key,
+            limit=self._settings.limit(),
+            window_seconds=float(self._settings.window_seconds()),
+        )
+        if admitted:
+            await self._app(scope, receive, send)
+            return
+
+        response = self._rate_limited_response(self._settings.window_seconds())
+        await response(scope, receive, send)
+
+    def _client_key(self, scope: Scope) -> str:
+        """Extract the client identity for bucketing.
+
+        Uses the transport peer address (``scope["client"]``) by default. When
+        the settings opt in to trusting ``X-Forwarded-For`` (deployments
+        behind a proxy that overwrites the header), the first — leftmost —
+        address in the header wins instead.
+
+        Args:
+            scope: The ASGI connection scope.
+
+        Returns:
+            The client IP string, or ``unknown`` when the transport exposes no
+            peer address.
+        """
+        if self._settings.trust_forwarded_for():
+            forwarded = self._forwarded_for(scope)
+            if forwarded is not None:
+                return forwarded
+
+        client = scope.get("client")
+        if client is None:
+            return self._UNKNOWN_CLIENT_KEY
+        return str(client[0])
+
+    def _forwarded_for(self, scope: Scope) -> str | None:
+        """Return the leftmost ``X-Forwarded-For`` address, if present.
+
+        Args:
+            scope: The ASGI connection scope.
+
+        Returns:
+            The first non-empty forwarded address, or ``None`` when the header
+            is absent or blank.
+        """
+        for name, value in scope.get("headers", []):
+            if bytes(name).lower() == self._FORWARDED_FOR_HEADER:
+                first = bytes(value).decode("latin-1").split(",")[0].strip()
+                return first if first else None
+        return None
+
+    def _rate_limited_response(self, window_seconds: int) -> JSONResponse:
+        """Build the enveloped 429 response for a refused request.
+
+        Args:
+            window_seconds: The window length, surfaced as the retry hint.
+
+        Returns:
+            A ``JSONResponse`` carrying the uniform error envelope and a
+            ``Retry-After`` header.
+        """
+        error = RateLimitedError(
+            message=self._RATE_LIMITED_MESSAGE,
+            details={"retry_after_seconds": window_seconds},
+        )
+        envelope = ErrorEnvelope(
+            error=ErrorDetail(code=error.code, message=error.message, details=error.details)
+        )
+        return JSONResponse(
+            status_code=error.http_status,
+            content=jsonable_encoder(envelope),
+            headers={"Retry-After": str(window_seconds)},
+        )

--- a/app/security/rate_limit_settings.py
+++ b/app/security/rate_limit_settings.py
@@ -1,0 +1,119 @@
+"""Configuration for the ``/auth/*`` per-IP rate limiter, read on demand.
+
+Per project convention (see :mod:`app.security.api_key_settings` and
+:mod:`app.auth.auth_settings`), fixed configuration is expressed through a
+settings class rather than bare module-level constants, and the environment is
+read on demand so values can change at runtime without re-importing. Every
+value may also be injected explicitly through the constructor, which the tests
+use to exercise a fully-configured limiter without mutating the process
+environment.
+
+Default posture: **disabled** (``LAVS_AUTH_RATE_LIMIT`` defaults to ``0``).
+This keeps every bare ``TestClient`` — and the whole existing test suite —
+byte-for-byte unaffected: the middleware is always wired but performs no
+counting until an operator opts in by setting a positive limit (typically via
+the Helm chart's environment). ``0`` (or an unset variable) disables limiting.
+"""
+
+import os
+
+
+class RateLimitSettings:
+    """Typed accessors over the ``LAVS_AUTH_RATE_*`` environment configuration."""
+
+    _LIMIT_ENV_VAR: str = "LAVS_AUTH_RATE_LIMIT"
+    _WINDOW_ENV_VAR: str = "LAVS_AUTH_RATE_WINDOW_SECONDS"
+    _TRUST_FORWARDED_ENV_VAR: str = "LAVS_AUTH_RATE_TRUST_FORWARDED_FOR"
+
+    _DEFAULT_LIMIT: int = 0
+    _DEFAULT_WINDOW_SECONDS: int = 60
+    _DEFAULT_MAX_TRACKED_CLIENTS: int = 1024
+    _TRUTHY_VALUES: tuple[str, ...] = ("1", "true", "yes", "on")
+
+    def __init__(
+        self,
+        limit: int | None = None,
+        window_seconds: int | None = None,
+        trust_forwarded_for: bool | None = None,
+        max_tracked_clients: int | None = None,
+    ) -> None:
+        """Initialise the settings.
+
+        Any argument left as ``None`` is resolved from the environment on
+        access; a supplied argument overrides the environment entirely (used by
+        tests to construct an enabled limiter deterministically).
+
+        Args:
+            limit: Maximum requests allowed per client per window; ``0``
+                disables limiting.
+            window_seconds: The sliding-window length in seconds.
+            trust_forwarded_for: Whether to honour ``X-Forwarded-For`` when
+                extracting the client IP.
+            max_tracked_clients: Upper bound on distinct client buckets kept in
+                memory (fixed configuration; not environment-driven).
+        """
+        self._limit = limit
+        self._window_seconds = window_seconds
+        self._trust_forwarded_for = trust_forwarded_for
+        self._max_tracked_clients = (
+            max_tracked_clients
+            if max_tracked_clients is not None
+            else self._DEFAULT_MAX_TRACKED_CLIENTS
+        )
+
+    @staticmethod
+    def _int_or_default(raw: str, default: int) -> int:
+        """Parse an env value as an int, falling back to ``default`` when malformed.
+
+        The settings are read per request inside the middleware, so a malformed
+        value must never raise — that would turn an operator typo into a 500 on
+        every ``/auth/*`` request. Falling back keeps the deployment on the safe
+        documented default instead.
+        """
+        try:
+            return int(raw)
+        except ValueError:
+            return default
+
+    def limit(self) -> int:
+        """Return the per-client request budget per window (``0`` disables)."""
+        if self._limit is not None:
+            return self._limit
+
+        raw = os.environ.get(self._LIMIT_ENV_VAR)
+        if raw is None or not raw.strip():
+            return self._DEFAULT_LIMIT
+        return self._int_or_default(raw, self._DEFAULT_LIMIT)
+
+    def window_seconds(self) -> int:
+        """Return the sliding-window length in seconds."""
+        if self._window_seconds is not None:
+            return self._window_seconds
+
+        raw = os.environ.get(self._WINDOW_ENV_VAR)
+        if raw is None or not raw.strip():
+            return self._DEFAULT_WINDOW_SECONDS
+        return self._int_or_default(raw, self._DEFAULT_WINDOW_SECONDS)
+
+    def trust_forwarded_for(self) -> bool:
+        """Return whether ``X-Forwarded-For`` may name the client IP.
+
+        Defaults to **off**: the header is trivially spoofable by any direct
+        caller, so honouring it unconditionally would let an attacker rotate
+        forged addresses to evade the per-IP budget. Enable only when a
+        trusted reverse proxy in front of the app is known to overwrite the
+        header with the real client address.
+        """
+        if self._trust_forwarded_for is not None:
+            return self._trust_forwarded_for
+
+        raw = os.environ.get(self._TRUST_FORWARDED_ENV_VAR, "")
+        return raw.strip().lower() in self._TRUTHY_VALUES
+
+    def max_tracked_clients(self) -> int:
+        """Return the cap on distinct client buckets held in memory."""
+        return self._max_tracked_clients
+
+    def enabled(self) -> bool:
+        """Return ``True`` when limiting is active (positive limit and window)."""
+        return self.limit() > 0 and self.window_seconds() > 0

--- a/app/security/sliding_window_limiter.py
+++ b/app/security/sliding_window_limiter.py
@@ -1,0 +1,115 @@
+"""A stdlib-only, in-process sliding-window rate limiter."""
+
+import time
+from collections import deque
+from collections.abc import Callable
+
+
+class SlidingWindowLimiter:
+    """A per-key sliding-window-log limiter with a bounded key set.
+
+    Each key (a client IP for the auth middleware) owns a deque of admission
+    timestamps; a request is admitted when fewer than ``limit`` admissions fall
+    inside the trailing ``window_seconds``. Refused requests are **not**
+    recorded, so a blocked client regains its budget as soon as the window
+    slides past its earlier admissions.
+
+    Memory bound: at most ``max_keys`` buckets are kept, and each bucket holds
+    at most ``limit`` timestamps (stale entries are dropped on every touch), so
+    worst-case memory is ``max_keys x limit`` floats. When a new key would
+    exceed the cap, buckets whose newest admission has left the window are
+    pruned first; if every bucket is still live, the one with the oldest most
+    recent admission is evicted.
+
+    The clock is injectable (monotonic by default) so tests can drive window
+    roll-over deterministically.
+    """
+
+    _DEFAULT_MAX_KEYS: int = 1024
+
+    def __init__(
+        self,
+        max_keys: int | None = None,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        """Initialise an empty limiter.
+
+        Args:
+            max_keys: Upper bound on distinct keys tracked at once.
+            clock: Monotonic time source returning seconds (injectable for
+                tests).
+        """
+        self._max_keys: int = max_keys if max_keys is not None else self._DEFAULT_MAX_KEYS
+        self._clock: Callable[[], float] = clock if clock is not None else time.monotonic
+        self._admissions: dict[str, deque[float]] = {}
+
+    @property
+    def tracked_key_count(self) -> int:
+        """Number of distinct keys currently holding a bucket."""
+        return len(self._admissions)
+
+    def allow(self, key: str, limit: int, window_seconds: float) -> bool:
+        """Decide whether a request from ``key`` is admitted right now.
+
+        Args:
+            key: The client identity (an IP address for the middleware).
+            limit: Maximum admissions per key inside the window; a
+                non-positive limit admits everything (limiting disabled).
+            window_seconds: The trailing window length in seconds.
+
+        Returns:
+            ``True`` when the request is admitted (and recorded), ``False``
+            when the key has exhausted its budget for the current window.
+        """
+        if limit <= 0:
+            return True
+
+        now = self._clock()
+        cutoff = now - window_seconds
+
+        bucket = self._admissions.get(key)
+        if bucket is None:
+            if len(self._admissions) >= self._max_keys:
+                self._prune_stale(cutoff)
+            if len(self._admissions) >= self._max_keys:
+                self._evict_least_recent()
+            bucket = deque()
+            self._admissions[key] = bucket
+
+        while bucket and bucket[0] <= cutoff:
+            bucket.popleft()
+
+        if len(bucket) >= limit:
+            return False
+
+        bucket.append(now)
+        return True
+
+    def _prune_stale(self, cutoff: float) -> None:
+        """Drop every bucket whose newest admission predates ``cutoff``.
+
+        Args:
+            cutoff: Timestamps at or before this instant are outside the
+                window.
+        """
+        stale = [key for key, bucket in self._admissions.items() if bucket[-1] <= cutoff]
+        for key in stale:
+            del self._admissions[key]
+
+    def _evict_least_recent(self) -> None:
+        """Evict the key whose most recent admission is oldest."""
+        if not self._admissions:
+            return
+        oldest_key = min(self._admissions, key=self._newest_admission)
+        del self._admissions[oldest_key]
+
+    def _newest_admission(self, key: str) -> float:
+        """Return the newest admission timestamp recorded for ``key``.
+
+        Args:
+            key: A key currently holding a bucket.
+
+        Returns:
+            The most recent admission time for the key.
+        """
+        return self._admissions[key][-1]

--- a/helm/lavs/templates/NOTES.txt
+++ b/helm/lavs/templates/NOTES.txt
@@ -1,3 +1,20 @@
+{{- if and (not .Values.auth.modes) (not .Values.auth.existingSecret) }}
+
+*********************************************************************
+** WARNING: NO AUTHENTICATION CONFIGURED                           **
+**                                                                 **
+** auth.modes is empty and auth.existingSecret is not set, so the  **
+** LAVS API is deployed ANONYMOUS-WRITABLE: anyone who can reach   **
+** the service can create, modify, and delete data.                **
+**                                                                 **
+** Set auth.modes (e.g. "password" or "password,apikey") and/or    **
+** auth.existingSecret to a Secret carrying LAVS_AUTH_* / auth     **
+** credentials before exposing this release beyond a trusted       **
+** network. Auth rate limiting is also OFF unless                  **
+** LAVS_AUTH_RATE_LIMIT is set (see extraEnv in values.yaml).      **
+*********************************************************************
+{{- end }}
+
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}

--- a/helm/lavs/templates/deployment.yaml
+++ b/helm/lavs/templates/deployment.yaml
@@ -44,6 +44,21 @@ spec:
             - name: http
               containerPort: {{ .Values.containerPort | default 8080 }}
               protocol: TCP
+          {{- if or .Values.auth.modes .Values.extraEnv }}
+          env:
+            {{- if .Values.auth.modes }}
+            - name: LAVS_AUTH_MODES
+              value: {{ .Values.auth.modes | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.auth.existingSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.auth.existingSecret }}
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/helm/lavs/values.yaml
+++ b/helm/lavs/values.yaml
@@ -38,16 +38,51 @@ podAnnotations: {}
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+# Pod-level security context. The image runs as the dedicated non-root user
+# uid/gid 10001 (see Dockerfile); fsGroup matches so any mounted volumes are
+# group-writable by the app.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+# Container-level security context.
+# readOnlyRootFilesystem stays false because the embedded DuckDB backend writes
+# its database file (and WAL) inside the container at /app/app/test.db by
+# default; making the root filesystem read-only would break /ready unless the
+# DB path is redirected onto a mounted volume (use `volumes`/`volumeMounts`
+# plus app config to relocate the DB, then flip this to true).
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+
+# Authentication configuration (LAV-50). With neither `modes` nor `existingSecret`
+# set the API runs ANONYMOUS-WRITABLE — NOTES.txt prints a warning in that case.
+auth:
+  # Comma-separated auth modes injected as LAVS_AUTH_MODES (e.g. "password" or
+  # "password,apikey"). Empty disables authentication entirely.
+  modes: ""
+  # Name of an existing Kubernetes Secret whose keys are injected via envFrom
+  # (e.g. LAVS_API_KEY, LAVS_STYTCH_SECRET, LAVS_SESSION_TTL_SECONDS).
+  # Only rendered when set.
+  existingSecret: ""
+
+# Extra environment variables for the lavs container (name/value pairs).
+# Auth-adjacent knobs the app understands (add here or in auth.existingSecret):
+#   LAVS_AUTH_RATE_LIMIT: requests per window on auth endpoints; unset/0 = rate
+#     limiting DISABLED (the default). Suggested production value: "20".
+#   LAVS_AUTH_RATE_WINDOW_SECONDS: window size for the limit (default 60).
+#   LAVS_AUTH_RATE_TRUST_FORWARDED_FOR: default off; only enable behind a
+#     trusted reverse proxy that sets X-Forwarded-For.
+extraEnv: []
+# - name: LAVS_AUTH_RATE_LIMIT
+#   value: "20"
+# - name: LAVS_AUTH_RATE_WINDOW_SECONDS
+#   value: "60"
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ constraint-dependencies = [
     "starlette>=1.3.1",  # DoS via form limits, SSRF/UNC, host-header poisoning
     "idna>=3.15",        # idna.encode() bypass of CVE-2024-3651 fix
     "pygments>=2.20.0",  # ReDoS in GUID regex
+    "click>=8.3.3",      # PYSEC-2026-2132 (found by the P8 CI pip-audit gate)
 ]
 
 [tool.ruff]

--- a/tests/integration/routers/test_auth_rate_limit.py
+++ b/tests/integration/routers/test_auth_rate_limit.py
@@ -1,0 +1,106 @@
+"""Integration tests for the ``/auth/*`` per-IP rate limit on the real app.
+
+Exercises the full stack (``app.main.app`` with its wired
+``RateLimitMiddleware``): the limit is enabled through the environment before
+requests are made — settings are read per request, so no restart is needed —
+and the trusted ``X-Forwarded-For`` flag is switched on so each test can claim
+a unique client IP. That keeps tests isolated from one another even though the
+middleware instance (and its buckets) lives for the whole process.
+"""
+
+import uuid
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _unique_ip() -> str:
+    """Return a practically collision-free RFC1918 address for one test."""
+    value = uuid.uuid4().int
+    return f"10.{(value >> 16) & 255}.{(value >> 8) & 255}.{value & 255}"
+
+
+@pytest.fixture()
+def limited_client(test_db: str, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """Yield a lifespan-active client with a 3-request/hour limit enabled.
+
+    API-key auth is also configured so a resource route can be exercised with
+    a valid credential while the auth surface is throttled.
+    """
+    monkeypatch.setenv("LAVS_AUTH_RATE_LIMIT", "3")
+    monkeypatch.setenv("LAVS_AUTH_RATE_WINDOW_SECONDS", "3600")
+    monkeypatch.setenv("LAVS_AUTH_RATE_TRUST_FORWARDED_FOR", "true")
+    monkeypatch.setenv("LAVS_AUTH_MODES", "password,apikey")
+    monkeypatch.setenv("LAVS_API_KEY", "rate-limit-suite-key")
+
+    from app.main import app
+
+    with TestClient(app) as client:
+        yield client
+
+
+class TestAuthRateLimit:
+    """The wired middleware throttles /auth/* per client IP."""
+
+    def test_auth_route_returns_429_envelope_when_exhausted(
+        self, limited_client: TestClient
+    ) -> None:
+        """The fourth login attempt from one IP is refused with the envelope."""
+        # Arrange
+        headers = {"X-Forwarded-For": _unique_ip()}
+        body = {"email": "probe@example.com", "password": "wrong-password-123"}
+        for _ in range(3):
+            response = limited_client.post("/auth/login", json=body, headers=headers)
+            assert response.status_code == 401
+
+        # Act
+        refused = limited_client.post("/auth/login", json=body, headers=headers)
+
+        # Assert
+        assert refused.status_code == 429
+        payload = refused.json()
+        assert payload["error"]["code"] == "rate_limited"
+        assert payload["error"]["message"]
+        assert payload["error"]["details"] == {"retry_after_seconds": 3600}
+        assert refused.headers["Retry-After"] == "3600"
+
+    def test_other_ip_keeps_its_own_budget(self, limited_client: TestClient) -> None:
+        """Exhausting one IP leaves a different client unthrottled."""
+        # Arrange
+        exhausted = {"X-Forwarded-For": _unique_ip()}
+        body = {"email": "probe@example.com", "password": "wrong-password-123"}
+        for _ in range(3):
+            limited_client.post("/auth/login", json=body, headers=exhausted)
+        assert limited_client.post("/auth/login", json=body, headers=exhausted).status_code == 429
+
+        # Act
+        fresh = limited_client.post(
+            "/auth/login", json=body, headers={"X-Forwarded-For": _unique_ip()}
+        )
+
+        # Assert — a fresh IP gets the normal (generic 401) auth answer.
+        assert fresh.status_code == 401
+
+    def test_resource_route_with_valid_key_is_never_limited(
+        self, limited_client: TestClient
+    ) -> None:
+        """Only /auth/* is throttled: an authenticated resource route is not."""
+        # Arrange — exhaust the auth budget for this IP first.
+        headers = {"X-Forwarded-For": _unique_ip()}
+        body = {"email": "probe@example.com", "password": "wrong-password-123"}
+        for _ in range(3):
+            limited_client.post("/auth/login", json=body, headers=headers)
+        assert limited_client.post("/auth/login", json=body, headers=headers).status_code == 429
+
+        # Act — hit a credentialed resource route well past the auth budget.
+        responses = [
+            limited_client.get(
+                "/products",
+                headers={"X-API-Key": "rate-limit-suite-key", **headers},
+            )
+            for _ in range(6)
+        ]
+
+        # Assert
+        assert all(response.status_code == 200 for response in responses)

--- a/tests/integration/routers/test_products.py
+++ b/tests/integration/routers/test_products.py
@@ -79,6 +79,18 @@ class TestCreateProduct:
         # Assert
         assert response.status_code == 422
 
+    def test_over_long_name_returns_422_envelope(self, client: TestClient) -> None:
+        """A name over the 256-character cap yields the uniform 422 envelope."""
+        # Act
+        response = client.post("/products", json={"name": "n" * 257})
+
+        # Assert
+        assert response.status_code == 422
+        error = response.json()["error"]
+        assert error["code"] == "validation_error"
+        assert error["message"] == "Request validation failed."
+        assert "errors" in error["details"]
+
 
 class TestGetProduct:
     """``GET /products/{product_id}``."""

--- a/tests/unit/auth/session/test_session_service.py
+++ b/tests/unit/auth/session/test_session_service.py
@@ -1,5 +1,8 @@
 """Unit tests for :class:`SessionService` against an in-memory database."""
 
+import os
+import time
+from datetime import UTC, datetime, timedelta
 from unittest import IsolatedAsyncioTestCase
 
 import duckdb
@@ -62,13 +65,41 @@ class TestSessionService(IsolatedAsyncioTestCase):
         # Act
         self._service.create_session(self._conn, user_id=self._user_id, ttl_seconds=3600)
 
-        # Assert
+        # Assert — compare against a bound naive-UTC "now" (not the database's
+        # CURRENT_TIMESTAMP) so the check holds under any host time zone.
         row = self._conn.execute(
-            "SELECT expires_at > CURRENT_TIMESTAMP FROM sessions WHERE user_id = ?",
-            [self._user_id],
+            "SELECT expires_at > ? FROM sessions WHERE user_id = ?",
+            [datetime.now(UTC).replace(tzinfo=None), self._user_id],
         ).fetchone()
         assert row is not None
         assert row[0] is True
+
+    async def test_expiry_is_utc_even_under_shifted_local_timezone(self) -> None:
+        """A monkeypatched local TZ never shifts the stored (UTC) expiry."""
+        # Arrange
+        await self._seed_user()
+        saved_tz = os.environ.get("TZ")
+        os.environ["TZ"] = "Pacific/Kiritimati"  # UTC+14 — the maximal shift
+        time.tzset()
+        try:
+            # Act
+            self._service.create_session(self._conn, user_id=self._user_id, ttl_seconds=3600)
+        finally:
+            if saved_tz is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = saved_tz
+            time.tzset()
+
+        # Assert — the stored expiry is naive UTC + ttl, not local time + ttl.
+        row = self._conn.execute(
+            "SELECT expires_at FROM sessions WHERE user_id = ?", [self._user_id]
+        ).fetchone()
+        assert row is not None
+        stored: datetime = row[0]
+        assert stored.tzinfo is None
+        expected = datetime.now(UTC).replace(tzinfo=None) + timedelta(seconds=3600)
+        assert abs((stored - expected).total_seconds()) < 5
 
     async def test_lookup_active_returns_user_id(self) -> None:
         """A live session resolves to its owning user id."""

--- a/tests/unit/auth/signup/test_signup_model.py
+++ b/tests/unit/auth/signup/test_signup_model.py
@@ -44,3 +44,26 @@ class TestSignupModel(TestCase):
 
         # Assert
         assert len(model.password) == SignupPolicy.MIN_PASSWORD_LENGTH
+
+    def test_maximum_length_password_is_accepted(self) -> None:
+        """A password exactly at the 128-character cap is accepted."""
+        # Act
+        model = SignupModel(email="engineer@example.com", password="a" * 128)
+
+        # Assert
+        assert len(model.password) == 128
+
+    def test_over_length_password_is_rejected(self) -> None:
+        """A password over the 128-character cap fails validation."""
+        # Act / Assert
+        with self.assertRaises(ValidationError):
+            SignupModel(email="engineer@example.com", password="a" * 129)
+
+    def test_over_length_email_is_rejected(self) -> None:
+        """An email over the 320-character RFC ceiling fails validation."""
+        # Arrange
+        email = "a" * 321 + "@example.com"
+
+        # Act / Assert
+        with self.assertRaises(ValidationError):
+            SignupModel(email=email, password=self._valid_password())

--- a/tests/unit/auth/signup/test_signup_service.py
+++ b/tests/unit/auth/signup/test_signup_service.py
@@ -3,6 +3,7 @@
 from unittest import IsolatedAsyncioTestCase
 
 import duckdb
+import psycopg.errors
 
 from app.auth.auth_settings import AuthSettings
 from app.auth.password_hasher import PasswordHasher
@@ -16,6 +17,22 @@ from app.errors.conflict_error import ConflictError
 from app.errors.domain_not_allowed_error import DomainNotAllowedError
 from app.mail.capture_mailer import CaptureMailer
 from app.models.requests.signup_model import SignupModel
+
+
+class _RacingUserRepository(UserRepository):
+    """A repository whose insert always loses the duplicate-email race.
+
+    ``get_user_by_email`` behaves normally (so the availability pre-check
+    passes), while ``create_user`` raises the injected driver constraint
+    error — simulating a concurrent sign-up that inserted the row between the
+    pre-check and our insert.
+    """
+
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    async def create_user(self, *args: object, **kwargs: object) -> object:  # type: ignore[override]
+        raise self._error
 
 
 class TestSignupService(IsolatedAsyncioTestCase):
@@ -85,6 +102,47 @@ class TestSignupService(IsolatedAsyncioTestCase):
         # Act / Assert
         with self.assertRaises(ConflictError):
             await self._register(settings)
+
+    async def _register_with_racing_insert(self, error: Exception) -> ConflictError:
+        """Register with a repository whose insert raises ``error``; return the 409."""
+        service = SignupService(
+            users=_RacingUserRepository(error),
+            verification_settings=VerificationSettings(ttl_seconds=3600),
+        )
+        settings = AuthSettings(allowed_email_domains=())
+        with self.assertRaises(ConflictError) as caught:
+            await service.register(
+                conn=self._conn, mailer=self._mailer, model=self._body(), settings=settings
+            )
+        return caught.exception
+
+    async def test_duckdb_insert_race_raises_same_conflict(self) -> None:
+        """A DuckDB unique-constraint loss maps to the same 409 as the pre-check."""
+        # Arrange
+        driver_text = 'Duplicate key "email: engineer@example.com" violates unique constraint'
+
+        # Act
+        error = await self._register_with_racing_insert(duckdb.ConstraintException(driver_text))
+
+        # Assert — same generic message; no driver text or chained cause leaks.
+        assert error.message == "This email address cannot be registered."
+        assert driver_text not in str(error)
+        assert error.__cause__ is None
+        assert self._mailer.messages() == ()
+
+    async def test_postgres_insert_race_raises_same_conflict(self) -> None:
+        """A PostgreSQL unique-violation loss maps to the same 409 as the pre-check."""
+        # Arrange
+        driver_text = 'duplicate key value violates unique constraint "users_email_key"'
+
+        # Act
+        error = await self._register_with_racing_insert(psycopg.errors.UniqueViolation(driver_text))
+
+        # Assert — same generic message; no driver text or chained cause leaks.
+        assert error.message == "This email address cannot be registered."
+        assert driver_text not in str(error)
+        assert error.__cause__ is None
+        assert self._mailer.messages() == ()
 
     async def test_password_is_stored_hashed(self) -> None:
         """The stored password differs from plaintext yet verifies."""

--- a/tests/unit/auth/signup/test_verification_token_repository.py
+++ b/tests/unit/auth/signup/test_verification_token_repository.py
@@ -1,5 +1,8 @@
 """Unit tests for :class:`VerificationTokenRepository` over an in-memory DB."""
 
+import os
+import time
+from datetime import UTC, datetime, timedelta
 from unittest import IsolatedAsyncioTestCase
 
 import duckdb
@@ -76,3 +79,51 @@ class TestVerificationTokenRepository(IsolatedAsyncioTestCase):
         """A hash that was never issued is never active."""
         # Act / Assert
         assert await self._repo.find_active(self._conn, "never-issued") is None
+
+    async def test_issue_expiry_is_utc_even_under_shifted_local_timezone(self) -> None:
+        """A monkeypatched local TZ never shifts the stored (UTC) expiry."""
+        # Arrange
+        await self._seed_user()
+        saved_tz = os.environ.get("TZ")
+        os.environ["TZ"] = "Pacific/Kiritimati"  # UTC+14 — the maximal shift
+        time.tzset()
+        try:
+            # Act
+            await self._repo.issue(self._conn, "hash-utc", self._user_id, ttl_seconds=3600)
+        finally:
+            if saved_tz is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = saved_tz
+            time.tzset()
+
+        # Assert — the stored expiry is naive UTC + ttl, not local time + ttl.
+        row = self._conn.execute(
+            "SELECT expires_at FROM email_verification_tokens WHERE token_hash = ?",
+            ["hash-utc"],
+        ).fetchone()
+        assert row is not None
+        stored: datetime = row[0]
+        assert stored.tzinfo is None
+        expected = datetime.now(UTC).replace(tzinfo=None) + timedelta(seconds=3600)
+        assert abs((stored - expected).total_seconds()) < 5
+
+    async def test_consume_stamps_naive_utc_timestamp(self) -> None:
+        """``consumed_at`` is stamped as a naive UTC instant."""
+        # Arrange
+        await self._seed_user()
+        await self._repo.issue(self._conn, "hash-c", self._user_id, ttl_seconds=3600)
+
+        # Act
+        await self._repo.consume(self._conn, "hash-c")
+
+        # Assert
+        row = self._conn.execute(
+            "SELECT consumed_at FROM email_verification_tokens WHERE token_hash = ?",
+            ["hash-c"],
+        ).fetchone()
+        assert row is not None
+        stamped: datetime = row[0]
+        assert stamped.tzinfo is None
+        now_utc = datetime.now(UTC).replace(tzinfo=None)
+        assert abs((stamped - now_utc).total_seconds()) < 5

--- a/tests/unit/errors/test_error_envelope_handlers.py
+++ b/tests/unit/errors/test_error_envelope_handlers.py
@@ -11,6 +11,7 @@ from app.errors.error_code import ErrorCode
 from app.errors.forbidden_error import ForbiddenError
 from app.errors.handlers import register_error_handlers
 from app.errors.not_found_error import NotFoundError
+from app.errors.rate_limited_error import RateLimitedError
 
 
 def _build_app() -> FastAPI:
@@ -37,6 +38,14 @@ def _build_app() -> FastAPI:
     @app.get("/teapot")
     def _teapot() -> None:
         raise HTTPException(status_code=418, detail="i am a teapot")
+
+    @app.get("/rate-limited")
+    def _rate_limited() -> None:
+        raise RateLimitedError("too many requests", {"retry_after_seconds": 60})
+
+    @app.get("/http-429")
+    def _http_429() -> None:
+        raise HTTPException(status_code=429, detail="slow down")
 
     return app
 
@@ -86,6 +95,18 @@ class TestDomainErrorEnvelopes:
         assert body["error"]["message"] == "not permitted"
         assert body["error"]["details"] == {"resource": "release"}
 
+    def test_rate_limited_returns_429_envelope(self, client: TestClient) -> None:
+        """``RateLimitedError`` serializes as a 429 ``rate_limited`` envelope."""
+        # Act
+        response = client.get("/rate-limited")
+
+        # Assert
+        assert response.status_code == 429
+        body = response.json()
+        assert body["error"]["code"] == ErrorCode.RATE_LIMITED.value
+        assert body["error"]["message"] == "too many requests"
+        assert body["error"]["details"] == {"retry_after_seconds": 60}
+
 
 class TestFrameworkErrorEnvelopes:
     """Framework validation and HTTP errors map to the envelope too."""
@@ -111,3 +132,14 @@ class TestFrameworkErrorEnvelopes:
         body = response.json()
         assert body["error"]["code"] == ErrorCode.HTTP_ERROR.value
         assert body["error"]["message"] == "i am a teapot"
+
+    def test_http_429_maps_to_rate_limited_code(self, client: TestClient) -> None:
+        """A framework 429 carries the specific ``rate_limited`` envelope code."""
+        # Act
+        response = client.get("/http-429")
+
+        # Assert
+        assert response.status_code == 429
+        body = response.json()
+        assert body["error"]["code"] == ErrorCode.RATE_LIMITED.value
+        assert body["error"]["message"] == "slow down"

--- a/tests/unit/events/test_event_bus.py
+++ b/tests/unit/events/test_event_bus.py
@@ -3,7 +3,7 @@
 from unittest import IsolatedAsyncioTestCase
 
 from app.events.domain_event import DomainEvent
-from app.events.event_bus import EventBus
+from app.events.event_bus import QUEUE_MAXSIZE, EventBus
 from app.events.event_type import EventType
 
 PRODUCT_A = "01AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -124,3 +124,71 @@ class TestEventBus(IsolatedAsyncioTestCase):
         assert staying.qsize() == 1
         assert leaving.empty()
         assert bus.subscriber_count(PRODUCT_A) == 1
+
+
+class TestEventBusBackpressure(IsolatedAsyncioTestCase):
+    """Bounded queues with drop-oldest overflow (LAV-52 L-6)."""
+
+    async def test_subscriber_queue_is_bounded(self) -> None:
+        """A fresh subscriber queue carries the configured bound."""
+        # Arrange
+        bus = EventBus()
+
+        # Act
+        queue = bus.subscribe(PRODUCT_A)
+
+        # Assert
+        assert queue.maxsize == QUEUE_MAXSIZE
+
+    async def test_overflow_drops_oldest_event(self) -> None:
+        """Publishing past the bound evicts the oldest event, keeps the newest."""
+        # Arrange
+        bus = EventBus()
+        queue = bus.subscribe(PRODUCT_A)
+        events = [_event(PRODUCT_A, component_id=f"c{index}") for index in range(QUEUE_MAXSIZE + 1)]
+
+        # Act: one publish more than the queue can hold.
+        for event in events:
+            await bus.publish(event)
+
+        # Assert: oldest (events[0]) was dropped; order otherwise preserved.
+        assert queue.qsize() == QUEUE_MAXSIZE
+        drained = [queue.get_nowait() for _ in range(queue.qsize())]
+        assert drained[0] is events[1]
+        assert drained[-1] is events[-1]
+        assert events[0] not in drained
+
+    async def test_publish_to_full_queue_never_raises(self) -> None:
+        """The publisher completes normally well past the overflow point."""
+        # Arrange
+        bus = EventBus()
+        queue = bus.subscribe(PRODUCT_A)
+
+        # Act: keep publishing well past capacity — must never raise or block.
+        for index in range(QUEUE_MAXSIZE + 10):
+            await bus.publish(_event(PRODUCT_A, component_id=f"c{index}"))
+
+        # Assert: the queue holds exactly the newest QUEUE_MAXSIZE events.
+        assert queue.qsize() == QUEUE_MAXSIZE
+        newest = queue.get_nowait()
+        assert newest.data["component_id"] == "c10"
+
+    async def test_overflow_on_one_queue_does_not_affect_sibling(self) -> None:
+        """A stalled subscriber overflowing does not disturb a healthy sibling."""
+        # Arrange
+        bus = EventBus()
+        stalled = bus.subscribe(PRODUCT_A)
+        healthy = bus.subscribe(PRODUCT_A)
+        for index in range(QUEUE_MAXSIZE):
+            await bus.publish(_event(PRODUCT_A, component_id=f"fill{index}"))
+        while not healthy.empty():
+            healthy.get_nowait()
+
+        # Act: the next publish overflows only the stalled queue.
+        final = _event(PRODUCT_A, component_id="final")
+        await bus.publish(final)
+
+        # Assert
+        assert stalled.qsize() == QUEUE_MAXSIZE
+        assert healthy.qsize() == 1
+        assert healthy.get_nowait() is final

--- a/tests/unit/mail/test_capture_mailer.py
+++ b/tests/unit/mail/test_capture_mailer.py
@@ -51,6 +51,37 @@ class TestCaptureMailer:
         assert result.subject == "Second"
         assert mailer.last_for("missing@example.com") is None
 
+    def test_ring_buffer_evicts_oldest_at_capacity(self) -> None:
+        """At capacity, each new send evicts the oldest capture."""
+        # Arrange
+        mailer = CaptureMailer(max_messages=3)
+        for index in range(3):
+            mailer.send(to=f"user{index}@example.com", subject=f"S{index}", body=str(index))
+
+        # Act
+        mailer.send(to="user3@example.com", subject="S3", body="3")
+
+        # Assert — capped at 3, oldest gone, newest present, order preserved.
+        retained = mailer.messages()
+        assert len(retained) == 3
+        assert [message.subject for message in retained] == ["S1", "S2", "S3"]
+        assert mailer.last_for("user0@example.com") is None
+
+    def test_default_capacity_is_bounded_at_100(self) -> None:
+        """The default ring never grows past 100 retained messages."""
+        # Arrange
+        mailer = CaptureMailer()
+
+        # Act
+        for index in range(150):
+            mailer.send(to="user@example.com", subject=f"S{index}", body=str(index))
+
+        # Assert
+        assert len(mailer.messages()) == 100
+        last = mailer.last_message()
+        assert last is not None
+        assert last.subject == "S149"
+
     def test_clear_empties_the_buffer(self) -> None:
         """``clear`` discards all captured messages."""
         # Arrange

--- a/tests/unit/models/test_request_max_len.py
+++ b/tests/unit/models/test_request_max_len.py
@@ -1,0 +1,175 @@
+"""Boundary tests for the ``MaxLen`` caps on request models (LAV-51 L-3).
+
+Each cap is exercised at the boundary: a value exactly at the cap validates,
+one character over raises ``ValidationError``. The caps are: names/labels 256,
+descriptions/notes 4096, email 320 (RFC ceiling), password 128, tokens 256,
+``stytch_token`` 4096.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.requests.create_component_model import CreateComponentModel
+from app.models.requests.create_product_model import CreateProductModel
+from app.models.requests.create_version_model import CreateVersionModel
+from app.models.requests.cut_release_model import CutReleaseModel
+from app.models.requests.login_model import LoginModel
+from app.models.requests.stytch_callback_model import StytchCallbackModel
+from app.models.requests.verify_model import VerifyModel
+
+ULID = "01KW8WHA6STWW5N1VYRSHDTK1N"
+
+
+class TestNameCaps:
+    """Names and labels are capped at 256 characters."""
+
+    def test_product_name_at_cap_is_accepted(self) -> None:
+        """A 256-character product name validates."""
+        # Act
+        model = CreateProductModel(name="n" * 256)
+
+        # Assert
+        assert len(model.name) == 256
+
+    def test_product_name_over_cap_is_rejected(self) -> None:
+        """A 257-character product name fails validation."""
+        # Act / Assert
+        with pytest.raises(ValidationError):
+            CreateProductModel(name="n" * 257)
+
+    def test_component_name_over_cap_is_rejected(self) -> None:
+        """A 257-character component name fails validation."""
+        # Act / Assert
+        with pytest.raises(ValidationError):
+            CreateComponentModel(product_id=ULID, name="n" * 257, kind="service")
+
+    def test_release_label_at_cap_is_accepted(self) -> None:
+        """A 256-character release label validates."""
+        # Act
+        model = CutReleaseModel(label="l" * 256)
+
+        # Assert
+        assert model.label is not None
+        assert len(model.label) == 256
+
+    def test_release_label_over_cap_is_rejected(self) -> None:
+        """A 257-character release label fails validation."""
+        # Act / Assert
+        with pytest.raises(ValidationError):
+            CutReleaseModel(label="l" * 257)
+
+
+class TestFreeTextCaps:
+    """Descriptions and notes are capped at 4096 characters."""
+
+    def test_product_description_at_cap_is_accepted(self) -> None:
+        """A 4096-character description validates."""
+        # Act
+        model = CreateProductModel(name="Aurora", description="d" * 4096)
+
+        # Assert
+        assert model.description is not None
+        assert len(model.description) == 4096
+
+    def test_product_description_over_cap_is_rejected(self) -> None:
+        """A 4097-character description fails validation."""
+        # Act / Assert
+        with pytest.raises(ValidationError):
+            CreateProductModel(name="Aurora", description="d" * 4097)
+
+    def test_release_notes_at_cap_are_accepted(self) -> None:
+        """4096-character release notes validate."""
+        # Act
+        model = CutReleaseModel(notes="n" * 4096)
+
+        # Assert
+        assert model.notes is not None
+        assert len(model.notes) == 4096
+
+    def test_release_notes_over_cap_are_rejected(self) -> None:
+        """4097-character release notes fail validation."""
+        # Act / Assert
+        with pytest.raises(ValidationError):
+            CutReleaseModel(notes="n" * 4097)
+
+
+class TestVersionCaps:
+    """Version and prerelease strings are capped at 256 characters."""
+
+    def test_version_over_cap_is_rejected(self) -> None:
+        """A semver-shaped string longer than 256 characters fails validation."""
+        # Arrange: valid semver shape, driven over the cap by its prerelease tag.
+        long_version = "1.2.3-" + "a" * 256
+
+        # Act / Assert
+        with pytest.raises(ValidationError):
+            CreateVersionModel(component_id=ULID, version=long_version)
+
+    def test_prerelease_over_cap_is_rejected(self) -> None:
+        """A 257-character prerelease fails validation."""
+        # Act / Assert
+        with pytest.raises(ValidationError):
+            CreateVersionModel(component_id=ULID, version="1.2.3", prerelease="p" * 257)
+
+
+class TestCredentialCaps:
+    """Login email 320, password 128; tokens 256; stytch_token 4096."""
+
+    def test_login_email_at_cap_is_accepted(self) -> None:
+        """A 320-character email (RFC ceiling) validates on login."""
+        # Arrange
+        email = "a" * (320 - len("@example.com")) + "@example.com"
+
+        # Act
+        model = LoginModel(email=email, password="p" * 12)
+
+        # Assert
+        assert len(model.email) == 320
+
+    def test_login_email_over_cap_is_rejected(self) -> None:
+        """A 321-character email fails validation on login."""
+        # Act / Assert
+        with pytest.raises(ValidationError):
+            LoginModel(email="a" * 321, password="p" * 12)
+
+    def test_login_password_at_cap_is_accepted(self) -> None:
+        """A 128-character password validates on login."""
+        # Act
+        model = LoginModel(email="engineer@example.com", password="p" * 128)
+
+        # Assert
+        assert len(model.password) == 128
+
+    def test_login_password_over_cap_is_rejected(self) -> None:
+        """A 129-character password fails validation on login."""
+        # Act / Assert
+        with pytest.raises(ValidationError):
+            LoginModel(email="engineer@example.com", password="p" * 129)
+
+    def test_verify_token_at_cap_is_accepted(self) -> None:
+        """A 256-character verification token validates."""
+        # Act
+        model = VerifyModel(token="t" * 256)
+
+        # Assert
+        assert len(model.token) == 256
+
+    def test_verify_token_over_cap_is_rejected(self) -> None:
+        """A 257-character verification token fails validation."""
+        # Act / Assert
+        with pytest.raises(ValidationError):
+            VerifyModel(token="t" * 257)
+
+    def test_stytch_token_at_cap_is_accepted(self) -> None:
+        """A 4096-character Stytch session JWT validates."""
+        # Act
+        model = StytchCallbackModel(stytch_token="j" * 4096)
+
+        # Assert
+        assert len(model.stytch_token) == 4096
+
+    def test_stytch_token_over_cap_is_rejected(self) -> None:
+        """A 4097-character Stytch token fails validation."""
+        # Act / Assert
+        with pytest.raises(ValidationError):
+            StytchCallbackModel(stytch_token="j" * 4097)

--- a/tests/unit/security/test_api_key.py
+++ b/tests/unit/security/test_api_key.py
@@ -1,13 +1,9 @@
-"""Tests for the API key authentication module."""
-
-import asyncio
+"""Tests for the API key configuration helpers."""
 
 import pytest
-from fastapi import HTTPException
 
 from app.security.api_key import (
     API_KEY_ENV_VAR,
-    get_api_key,
     get_configured_api_key,
     is_authentication_enabled,
 )
@@ -52,47 +48,3 @@ class TestIsAuthenticationEnabled:
         """Test that False is returned when API key is empty string."""
         monkeypatch.setenv(API_KEY_ENV_VAR, "")
         assert is_authentication_enabled() is False
-
-
-class TestGetApiKey:
-    """Tests for get_api_key function."""
-
-    def test_allows_request_when_auth_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test that requests are allowed when authentication is disabled."""
-        monkeypatch.delenv(API_KEY_ENV_VAR, raising=False)
-        # Should not raise an exception - using asyncio.run for sync test
-        result = asyncio.run(get_api_key(api_key=None))
-        assert result == ""
-
-    def test_allows_request_when_auth_disabled_with_key(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Test that requests with any key are allowed when auth is disabled."""
-        monkeypatch.delenv(API_KEY_ENV_VAR, raising=False)
-        # Should not raise an exception even with a key provided
-        result = asyncio.run(get_api_key(api_key="any-key"))
-        assert result == "any-key"
-
-    def test_rejects_request_without_key_when_auth_enabled(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Test that requests without API key are rejected when auth is enabled."""
-        monkeypatch.setenv(API_KEY_ENV_VAR, "test-api-key")
-        with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(get_api_key(api_key=None))
-        assert exc_info.value.status_code == 401
-
-    def test_rejects_request_with_wrong_key_when_auth_enabled(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Test that requests with wrong API key are rejected."""
-        monkeypatch.setenv(API_KEY_ENV_VAR, "test-api-key")
-        with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(get_api_key(api_key="wrong-key"))
-        assert exc_info.value.status_code == 403
-
-    def test_allows_request_with_correct_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test that requests with correct API key are allowed."""
-        monkeypatch.setenv(API_KEY_ENV_VAR, "test-api-key")
-        result = asyncio.run(get_api_key(api_key="test-api-key"))
-        assert result == "test-api-key"

--- a/tests/unit/security/test_rate_limit_middleware.py
+++ b/tests/unit/security/test_rate_limit_middleware.py
@@ -1,0 +1,170 @@
+"""Unit tests for :class:`RateLimitMiddleware` over a throwaway app."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.errors.error_code import ErrorCode
+from app.security.rate_limit_middleware import RateLimitMiddleware
+from app.security.rate_limit_settings import RateLimitSettings
+
+
+def _build_client(settings: RateLimitSettings) -> TestClient:
+    """Build a client over a minimal app with the middleware installed.
+
+    Args:
+        settings: The injected (environment-free) rate-limit settings.
+
+    Returns:
+        A ``TestClient`` whose app has one ``/auth/*`` route and one
+        non-auth route.
+    """
+    app = FastAPI()
+
+    @app.post("/auth/ping")
+    def _auth_ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.get("/other/ping")
+    def _other_ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.add_middleware(RateLimitMiddleware, settings=settings)
+    return TestClient(app)
+
+
+class TestScopeAndDisabledMode:
+    """The middleware only ever touches enabled ``/auth/*`` traffic."""
+
+    def test_disabled_settings_never_limit(self) -> None:
+        """With a zero limit every /auth request passes through."""
+        # Arrange
+        client = _build_client(RateLimitSettings(limit=0, window_seconds=60))
+
+        # Act
+        responses = [client.post("/auth/ping") for _ in range(10)]
+
+        # Assert
+        assert all(response.status_code == 200 for response in responses)
+
+    def test_non_auth_paths_are_never_limited(self) -> None:
+        """A tiny budget on /auth leaves other paths completely alone."""
+        # Arrange
+        client = _build_client(RateLimitSettings(limit=1, window_seconds=3600))
+        assert client.post("/auth/ping").status_code == 200
+        assert client.post("/auth/ping").status_code == 429
+
+        # Act
+        responses = [client.get("/other/ping") for _ in range(5)]
+
+        # Assert
+        assert all(response.status_code == 200 for response in responses)
+
+
+class TestRefusal:
+    """Over-budget requests get the enveloped 429."""
+
+    def test_429_carries_error_envelope_and_retry_after(self) -> None:
+        """The refusal body is the uniform envelope with code rate_limited."""
+        # Arrange
+        client = _build_client(RateLimitSettings(limit=1, window_seconds=45))
+        assert client.post("/auth/ping").status_code == 200
+
+        # Act
+        response = client.post("/auth/ping")
+
+        # Assert
+        assert response.status_code == 429
+        body = response.json()
+        assert body["error"]["code"] == ErrorCode.RATE_LIMITED.value
+        assert body["error"]["message"]
+        assert body["error"]["details"] == {"retry_after_seconds": 45}
+        assert response.headers["Retry-After"] == "45"
+
+
+class TestClientIpExtraction:
+    """Bucketing key selection with and without the forwarded-for flag."""
+
+    def test_forwarded_for_ignored_by_default(self) -> None:
+        """Without the trust flag, forged X-Forwarded-For cannot reset budgets."""
+        # Arrange — every TestClient request shares the same transport peer.
+        client = _build_client(RateLimitSettings(limit=2, window_seconds=3600))
+
+        # Act — rotate forged addresses; the transport peer is still the key.
+        first = client.post("/auth/ping", headers={"X-Forwarded-For": "1.1.1.1"})
+        second = client.post("/auth/ping", headers={"X-Forwarded-For": "2.2.2.2"})
+        third = client.post("/auth/ping", headers={"X-Forwarded-For": "3.3.3.3"})
+
+        # Assert
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert third.status_code == 429
+
+    def test_forwarded_for_used_when_trusted(self) -> None:
+        """With the flag on, each forwarded address owns its own budget."""
+        # Arrange
+        client = _build_client(
+            RateLimitSettings(limit=1, window_seconds=3600, trust_forwarded_for=True)
+        )
+
+        # Act
+        first_a = client.post("/auth/ping", headers={"X-Forwarded-For": "9.9.9.1"})
+        second_a = client.post("/auth/ping", headers={"X-Forwarded-For": "9.9.9.1"})
+        first_b = client.post("/auth/ping", headers={"X-Forwarded-For": "9.9.9.2"})
+
+        # Assert
+        assert first_a.status_code == 200
+        assert second_a.status_code == 429
+        assert first_b.status_code == 200
+
+    def test_leftmost_forwarded_address_wins(self) -> None:
+        """A proxy chain header buckets on the original (leftmost) client."""
+        # Arrange
+        client = _build_client(
+            RateLimitSettings(limit=1, window_seconds=3600, trust_forwarded_for=True)
+        )
+
+        # Act
+        first = client.post("/auth/ping", headers={"X-Forwarded-For": "8.8.8.8, 10.0.0.1"})
+        second = client.post("/auth/ping", headers={"X-Forwarded-For": "8.8.8.8, 10.0.0.2"})
+
+        # Assert — same leftmost client, so the second request is refused.
+        assert first.status_code == 200
+        assert second.status_code == 429
+
+    def test_trusted_but_absent_header_falls_back_to_peer(self) -> None:
+        """With trust on but no header, the transport peer is still limited."""
+        # Arrange
+        client = _build_client(
+            RateLimitSettings(limit=1, window_seconds=3600, trust_forwarded_for=True)
+        )
+
+        # Act
+        first = client.post("/auth/ping")
+        second = client.post("/auth/ping")
+
+        # Assert
+        assert first.status_code == 200
+        assert second.status_code == 429
+
+
+class TestRuntimeToggle:
+    """Settings are read per request, so env changes apply immediately."""
+
+    def test_env_enable_takes_effect_without_restart(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An environment-backed settings object toggles limiting live."""
+        # Arrange
+        monkeypatch.delenv("LAVS_AUTH_RATE_LIMIT", raising=False)
+        monkeypatch.delenv("LAVS_AUTH_RATE_WINDOW_SECONDS", raising=False)
+        client = _build_client(RateLimitSettings())
+        assert client.post("/auth/ping").status_code == 200
+        assert client.post("/auth/ping").status_code == 200
+
+        # Act
+        monkeypatch.setenv("LAVS_AUTH_RATE_LIMIT", "1")
+        first_limited = client.post("/auth/ping")
+        second_limited = client.post("/auth/ping")
+
+        # Assert
+        assert first_limited.status_code == 200
+        assert second_limited.status_code == 429

--- a/tests/unit/security/test_rate_limit_settings.py
+++ b/tests/unit/security/test_rate_limit_settings.py
@@ -1,0 +1,125 @@
+"""Unit tests for :class:`RateLimitSettings`."""
+
+import pytest
+
+from app.security.rate_limit_settings import RateLimitSettings
+
+
+class TestDefaults:
+    """Default posture with a clean environment."""
+
+    def test_limiting_is_disabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With no environment set the limiter is off (limit 0)."""
+        # Arrange
+        monkeypatch.delenv("LAVS_AUTH_RATE_LIMIT", raising=False)
+        monkeypatch.delenv("LAVS_AUTH_RATE_WINDOW_SECONDS", raising=False)
+        settings = RateLimitSettings()
+
+        # Act / Assert
+        assert settings.limit() == 0
+        assert settings.window_seconds() == 60
+        assert settings.enabled() is False
+
+    def test_trust_forwarded_for_defaults_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``X-Forwarded-For`` is not trusted unless explicitly enabled."""
+        # Arrange
+        monkeypatch.delenv("LAVS_AUTH_RATE_TRUST_FORWARDED_FOR", raising=False)
+        settings = RateLimitSettings()
+
+        # Act / Assert
+        assert settings.trust_forwarded_for() is False
+
+    def test_max_tracked_clients_has_a_fixed_default(self) -> None:
+        """The bucket cap defaults to a fixed bound."""
+        # Arrange
+        settings = RateLimitSettings()
+
+        # Act / Assert
+        assert settings.max_tracked_clients() == 1024
+
+
+class TestEnvironmentReads:
+    """Values resolve from the ``LAVS_AUTH_RATE_*`` environment on demand."""
+
+    def test_limit_and_window_read_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Positive env values enable limiting with those numbers."""
+        # Arrange
+        monkeypatch.setenv("LAVS_AUTH_RATE_LIMIT", "20")
+        monkeypatch.setenv("LAVS_AUTH_RATE_WINDOW_SECONDS", "30")
+        settings = RateLimitSettings()
+
+        # Act / Assert
+        assert settings.limit() == 20
+        assert settings.window_seconds() == 30
+        assert settings.enabled() is True
+
+    def test_zero_limit_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An explicit ``0`` limit disables limiting."""
+        # Arrange
+        monkeypatch.setenv("LAVS_AUTH_RATE_LIMIT", "0")
+        settings = RateLimitSettings()
+
+        # Act / Assert
+        assert settings.enabled() is False
+
+    def test_blank_values_fall_back_to_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Whitespace-only env values behave as unset."""
+        # Arrange
+        monkeypatch.setenv("LAVS_AUTH_RATE_LIMIT", "   ")
+        monkeypatch.setenv("LAVS_AUTH_RATE_WINDOW_SECONDS", " ")
+        settings = RateLimitSettings()
+
+        # Act / Assert
+        assert settings.limit() == 0
+        assert settings.window_seconds() == 60
+
+    @pytest.mark.parametrize("raw", ["1", "true", "TRUE", "yes", "on"])
+    def test_truthy_trust_flag_values(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        """Common truthy spellings enable X-Forwarded-For trust."""
+        # Arrange
+        monkeypatch.setenv("LAVS_AUTH_RATE_TRUST_FORWARDED_FOR", raw)
+        settings = RateLimitSettings()
+
+        # Act / Assert
+        assert settings.trust_forwarded_for() is True
+
+    @pytest.mark.parametrize("raw", ["0", "false", "off", "nope", ""])
+    def test_falsy_trust_flag_values(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        """Anything else keeps the trust flag off."""
+        # Arrange
+        monkeypatch.setenv("LAVS_AUTH_RATE_TRUST_FORWARDED_FOR", raw)
+        settings = RateLimitSettings()
+
+        # Act / Assert
+        assert settings.trust_forwarded_for() is False
+
+
+class TestConstructorOverrides:
+    """Injected values override the environment entirely."""
+
+    def test_injected_values_win_over_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Constructor arguments shadow any environment configuration."""
+        # Arrange
+        monkeypatch.setenv("LAVS_AUTH_RATE_LIMIT", "5")
+        monkeypatch.setenv("LAVS_AUTH_RATE_WINDOW_SECONDS", "10")
+        monkeypatch.setenv("LAVS_AUTH_RATE_TRUST_FORWARDED_FOR", "true")
+        settings = RateLimitSettings(
+            limit=2,
+            window_seconds=99,
+            trust_forwarded_for=False,
+            max_tracked_clients=7,
+        )
+
+        # Act / Assert
+        assert settings.limit() == 2
+        assert settings.window_seconds() == 99
+        assert settings.trust_forwarded_for() is False
+        assert settings.max_tracked_clients() == 7
+
+    def test_zero_window_disables(self) -> None:
+        """A zero window disables limiting even with a positive limit."""
+        # Arrange
+        settings = RateLimitSettings(limit=5, window_seconds=0)
+
+        # Act / Assert
+        assert settings.enabled() is False

--- a/tests/unit/security/test_sliding_window_limiter.py
+++ b/tests/unit/security/test_sliding_window_limiter.py
@@ -1,0 +1,152 @@
+"""Unit tests for :class:`SlidingWindowLimiter`."""
+
+from app.security.sliding_window_limiter import SlidingWindowLimiter
+
+
+class FakeClock:
+    """A manually advanced monotonic clock for deterministic window tests."""
+
+    def __init__(self) -> None:
+        """Start the clock at zero."""
+        self.now: float = 0.0
+
+    def __call__(self) -> float:
+        """Return the current fake time."""
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        """Move the clock forward.
+
+        Args:
+            seconds: How far to advance.
+        """
+        self.now += seconds
+
+
+class TestBudget:
+    """Admission within and beyond the per-key budget."""
+
+    def test_admits_up_to_limit_then_refuses(self) -> None:
+        """Exactly ``limit`` requests are admitted inside one window."""
+        # Arrange
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(clock=clock)
+
+        # Act
+        outcomes = [limiter.allow("1.2.3.4", limit=3, window_seconds=60) for _ in range(5)]
+
+        # Assert
+        assert outcomes == [True, True, True, False, False]
+
+    def test_window_roll_over_restores_budget(self) -> None:
+        """Once earlier admissions leave the window the key is admitted again."""
+        # Arrange
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(clock=clock)
+        for _ in range(3):
+            assert limiter.allow("1.2.3.4", limit=3, window_seconds=60)
+        assert not limiter.allow("1.2.3.4", limit=3, window_seconds=60)
+
+        # Act
+        clock.advance(61)
+        admitted_after_window = limiter.allow("1.2.3.4", limit=3, window_seconds=60)
+
+        # Assert
+        assert admitted_after_window is True
+
+    def test_partial_roll_over_frees_only_expired_slots(self) -> None:
+        """The window slides: only admissions older than it stop counting."""
+        # Arrange
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(clock=clock)
+        assert limiter.allow("k", limit=2, window_seconds=60)
+        clock.advance(45)
+        assert limiter.allow("k", limit=2, window_seconds=60)
+        assert not limiter.allow("k", limit=2, window_seconds=60)
+
+        # Act — first admission (t=0) leaves the window at t>60; second (t=45) has not.
+        clock.advance(20)
+        third = limiter.allow("k", limit=2, window_seconds=60)
+        fourth = limiter.allow("k", limit=2, window_seconds=60)
+
+        # Assert
+        assert third is True
+        assert fourth is False
+
+    def test_per_key_isolation(self) -> None:
+        """One exhausted key never affects another key's budget."""
+        # Arrange
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(clock=clock)
+        for _ in range(2):
+            assert limiter.allow("10.0.0.1", limit=2, window_seconds=60)
+        assert not limiter.allow("10.0.0.1", limit=2, window_seconds=60)
+
+        # Act
+        other_admitted = limiter.allow("10.0.0.2", limit=2, window_seconds=60)
+
+        # Assert
+        assert other_admitted is True
+
+    def test_non_positive_limit_admits_everything(self) -> None:
+        """A limit of 0 (disabled) admits without recording anything."""
+        # Arrange
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(clock=clock)
+
+        # Act
+        outcomes = [limiter.allow("1.2.3.4", limit=0, window_seconds=60) for _ in range(10)]
+
+        # Assert
+        assert all(outcomes)
+        assert limiter.tracked_key_count == 0
+
+
+class TestMemoryBound:
+    """The tracked-key set never exceeds ``max_keys``."""
+
+    def test_stale_keys_are_pruned_at_the_cap(self) -> None:
+        """Keys whose admissions expired are dropped before evicting live ones."""
+        # Arrange
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(max_keys=3, clock=clock)
+        for index in range(3):
+            assert limiter.allow(f"stale-{index}", limit=5, window_seconds=60)
+        clock.advance(61)
+
+        # Act
+        admitted = limiter.allow("fresh", limit=5, window_seconds=60)
+
+        # Assert — all three stale buckets were pruned, only the fresh key remains.
+        assert admitted is True
+        assert limiter.tracked_key_count == 1
+
+    def test_live_key_evicted_when_cap_exceeded(self) -> None:
+        """When every bucket is live, the least recently admitted key is evicted."""
+        # Arrange
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(max_keys=2, clock=clock)
+        assert limiter.allow("oldest", limit=5, window_seconds=60)
+        clock.advance(1)
+        assert limiter.allow("newer", limit=5, window_seconds=60)
+        clock.advance(1)
+
+        # Act
+        admitted = limiter.allow("newest", limit=5, window_seconds=60)
+
+        # Assert — cap held at 2; the evicted key is the least recently seen.
+        assert admitted is True
+        assert limiter.tracked_key_count == 2
+
+    def test_cap_holds_under_many_distinct_keys(self) -> None:
+        """Hammering with unique keys never grows the map past the cap."""
+        # Arrange
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(max_keys=8, clock=clock)
+
+        # Act
+        for index in range(100):
+            limiter.allow(f"attacker-{index}", limit=5, window_seconds=60)
+
+        # Assert
+        assert limiter.tracked_key_count <= 8

--- a/uv.lock
+++ b/uv.lock
@@ -4,6 +4,7 @@ requires-python = ">=3.14"
 
 [manifest]
 constraints = [
+    { name = "click", specifier = ">=8.3.3" },
     { name = "idna", specifier = ">=3.15" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "starlette", specifier = ">=1.3.1" },
@@ -298,14 +299,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #37. Linear: LAV-48…52 (*P8 — v1 hardening (pre-tag)*) — the P7 R4 audit follow-ups, all adversarially verified closed by Gate B.

## What (4 parallel lanes)

- **H1 deploy envelope** (LAV-48, LAV-50, L-4): non-root uid 10001 container (DB write path proven live via `/ready` as non-root), digest-pinned base images, `HEALTHCHECK`, `.dockerignore` (which caught the host `test.db` silently shipping in images); helm `securityContext` real defaults; chart auth env wiring (`auth.modes` / `extraEnv` / `existingSecret`) + an **ANONYMOUS-WRITABLE** NOTES.txt banner when auth is unconfigured; **CI audit gates** — the pip-audit job found a real vuln on its first local run (`click` 8.3.1, PYSEC-2026-2132 → bumped via constraint to 8.4.2, gate now blocking with `pipefail` guarded) plus a pnpm-audit job (clean).
- **H2 rate limiting** (LAV-49): stdlib-only sliding-window per-IP limiter on `/auth/*` as pure-ASGI middleware (SSE never buffered) — **default-off** via `LAVS_AUTH_RATE_LIMIT` with per-request env reads (enable without restart; malformed values degrade to disabled, not 500), spoof-aware `X-Forwarded-For` opt-in, memory-bounded buckets with LRU eviction, 429s byte-identical to the handler envelope + `Retry-After`; `CaptureMailer` capped at 100.
- **H3 auth hygiene** (L-1, L-2, L-7): dead `get_api_key`/`ApiKeyDep` timing-oracle path deleted; UTC-correct expiry clocks with naive-UTC storage that round-trips identically on DuckDB and Postgres (pinned by TZ-shift tests at UTC+14); signup duplicate-email race → the same 409, no driver text, `from None`.
- **H4 input/stream caps** (L-3, L-6): `MaxLen` on every request-model string (names 256 · notes/descriptions 4096 · email 320 · password 128 · stytch_token 4096); bounded SSE queues (256) with atomic drop-oldest — publisher can never block or raise.

## Gates
- **A (enforcement): PASS** — 6 MINOR (the actionable one — malformed-env `int()` — fixed pre-commit; rest precedent-accepted/follow-up)
- **B (findings closure): PASS** — LAV-48…52 each **CONFIRMED-CLOSED** with file:line evidence; bypass attempts (`//auth`, `/AUTH/`, dot-segments) refuted; both LOW new-code items fixed pre-commit
- **C (integration):** BE **552** + coverage **96.35% ≥ 80** · FE 118 + build · Playwright 4/4 · final image: uid **10001**, probes 200/200, HEALTHCHECK **healthy** · helm lint + render (securityContext, env wiring, secretRef) verified

## Notes
- `readOnlyRootFilesystem` stays `false` (embedded DuckDB writes in-container; rationale + path-to-true documented in values.yaml).
- Rate limiting ships disabled; chart documents `LAVS_AUTH_RATE_LIMIT=20` / window 60 as suggested production values.
- Follow-up material (INFO): NOTES banner false-negatives on garbage `auth.modes`, rightmost-XFF semantics, `_utc_now()` DRY hoist, service-layer driver-exception mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)